### PR TITLE
fixes crash when editing input fields

### DIFF
--- a/flutter/message.go
+++ b/flutter/message.go
@@ -15,9 +15,9 @@ const (
 	TextUpdateStateMethod = "TextInputClient.updateEditingState"
 
 	// text
-	SetClientMethod       = "TextInput.setClient"
-	ClearClientMethod     = "TextInput.clearClient"
-	SetEditingStateMethod = "TextInput.setEditingState"
+	TextInputClientSet    = "TextInput.setClient"
+	TextInputClientClear  = "TextInput.clearClient"
+	TextInputSetEditState = "TextInput.setEditingState"
 )
 
 // Message is the json content of a PlatformMessage

--- a/gutter.go
+++ b/gutter.go
@@ -271,26 +271,24 @@ func onPlatformMessage(platMessage flutter.PlatformMessage, window unsafe.Pointe
 	}
 
 	if platMessage.Channel == flutter.TextInputChannel {
-
-		if message.Method == flutter.ClearClientMethod {
+		switch message.Method {
+		case flutter.TextInputClientClear:
 			state.clientID = 0
-		}
-
-		if message.Method == flutter.SetClientMethod {
+		case flutter.TextInputClientSet:
 			var body []interface{}
 			json.Unmarshal(message.Args, &body)
 			state.clientID = body[0].(float64)
-		}
-
-		if message.Method == flutter.SetEditingStateMethod {
+		case flutter.TextInputSetEditState:
 			if state.clientID != 0 {
 				editingState := flutter.ArgsEditingState{}
 				json.Unmarshal(message.Args, &editingState)
 				state.word = editingState.Text
+				state.selectionBase = editingState.SelectionBase
+				state.selectionExtent = editingState.SelectionExtent
 			}
-
+		default:
+			// log.Printf("unhandled text input method: %#v\n", platMessage.Message)
 		}
-
 	}
 
 	return true


### PR DESCRIPTION
- prefix text input methods uniformly.
- use a switch statement for selecting method behaviour.
- fix crashes in text input by properly setting initial
position of the cursor.

may fix #6, I didn't notice any issues with multiple text inputs. however I did notice issues when hitting backspace or inserting text. backspace would crash, and text inserts would be in the incorrect position.