### PR TITLE
Fixes Wrong Directory

### DIFF
--- a/example/simpleDemo/main.go
+++ b/example/simpleDemo/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	options := []gutter.Option{
 		gutter.OptionAssetPath(dir + "/flutter_project/demo/build/flutter_assets"),
-		gutter.OptionICUDataPath("icudtl.dat"),
+		gutter.OptionICUDataPath("/opt/flutter/bin/cache/artifacts/engine/linux-x64/icudtl.dat"),
 		gutter.OptionWindowInitializer(setIcon),
 	}
 

--- a/example/simpleDemo/main.go
+++ b/example/simpleDemo/main.go
@@ -5,7 +5,8 @@ import (
 	_ "image/png"
 	"log"
 	"os"
-	"path/filepath"
+	"path"
+	"runtime"
 
 	gutter "github.com/Drakirus/go-flutter-desktop-embedder"
 
@@ -17,14 +18,12 @@ func main() {
 		err error
 	)
 
-	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
-	if err != nil {
-		log.Fatal(err)
-	}
+	_, currentFilePath, _, _ := runtime.Caller(0)
+	dir := path.Dir(currentFilePath)
 
 	options := []gutter.Option{
 		gutter.OptionAssetPath(dir + "/flutter_project/demo/build/flutter_assets"),
-		gutter.OptionICUDataPath("/opt/flutter/bin/cache/artifacts/engine/linux-x64/icudtl.dat"),
+		gutter.OptionICUDataPath("icudtl.dat"),
 		gutter.OptionWindowInitializer(setIcon),
 	}
 
@@ -35,10 +34,8 @@ func main() {
 }
 
 func setIcon(window *glfw.Window) error {
-	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
-	if err != nil {
-		return err
-	}
+	_, currentFilePath, _, _ := runtime.Caller(0)
+	dir := path.Dir(currentFilePath)
 	imgFile, err := os.Open(dir + "/assets/icon.png")
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix: gets the directory of the running file instead of the binaries' temp folder as discussed in the comments of this: [stackoverflow](https://stackoverflow.com/questions/18537257/how-to-get-the-directory-of-the-currently-running-file)

SOLVED:
`2018/09/14 18:53:53 open C:\Users\USERNAME~1\AppData\Local\Temp\go-build482027730\b001\exe/assets/icon.png: The system cannot find the path specified.
exit status 1`