### PR TITLE
Adds Support For Multiple Projects

### DIFF
--- a/example/simpleDemo/main.go
+++ b/example/simpleDemo/main.go
@@ -5,6 +5,7 @@ import (
 	_ "image/png"
 	"log"
 	"os"
+	"path/filepath"
 
 	gutter "github.com/Drakirus/go-flutter-desktop-embedder"
 
@@ -16,8 +17,13 @@ func main() {
 		err error
 	)
 
+	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	options := []gutter.Option{
-		gutter.OptionAssetPath("flutter_project/demo/build/flutter_assets"),
+		gutter.OptionAssetPath(dir + "/flutter_project/demo/build/flutter_assets"),
 		gutter.OptionICUDataPath("/opt/flutter/bin/cache/artifacts/engine/linux-x64/icudtl.dat"),
 		gutter.OptionWindowInitializer(setIcon),
 	}
@@ -29,7 +35,11 @@ func main() {
 }
 
 func setIcon(window *glfw.Window) error {
-	imgFile, err := os.Open("assets/icon.png")
+	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	if err != nil {
+		return err
+	}
+	imgFile, err := os.Open(dir + "/assets/icon.png")
 	if err != nil {
 		return err
 	}

--- a/example/simpleDemo/main.go
+++ b/example/simpleDemo/main.go
@@ -23,7 +23,7 @@ func main() {
 
 	options := []gutter.Option{
 		gutter.OptionAssetPath(dir + "/flutter_project/demo/build/flutter_assets"),
-		gutter.OptionICUDataPath("icudtl.dat"),
+		gutter.OptionICUDataPath("/opt/flutter/bin/cache/artifacts/engine/linux-x64/icudtl.dat"),
 		gutter.OptionWindowInitializer(setIcon),
 	}
 

--- a/example/simpleDemo/main.go
+++ b/example/simpleDemo/main.go
@@ -5,7 +5,8 @@ import (
 	_ "image/png"
 	"log"
 	"os"
-	"path/filepath"
+	"path"
+	"runtime"
 
 	gutter "github.com/Drakirus/go-flutter-desktop-embedder"
 
@@ -17,14 +18,12 @@ func main() {
 		err error
 	)
 
-	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
-	if err != nil {
-		log.Fatal(err)
-	}
+	_, currentFilePath, _, _ := runtime.Caller(0)
+	dir := path.Dir(currentFilePath)
 
 	options := []gutter.Option{
 		gutter.OptionAssetPath(dir + "/flutter_project/demo/build/flutter_assets"),
-		gutter.OptionICUDataPath("/opt/flutter/bin/cache/artifacts/engine/linux-x64/icudtl.dat"),
+		gutter.OptionICUDataPath("icudtl.dat"),
 		gutter.OptionWindowInitializer(setIcon),
 	}
 
@@ -35,10 +34,8 @@ func main() {
 }
 
 func setIcon(window *glfw.Window) error {
-	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
-	if err != nil {
-		return err
-	}
+	_, currentFilePath, _, _ := runtime.Caller(0)
+	dir := path.Dir(currentFilePath)
 	imgFile, err := os.Open(dir + "/assets/icon.png")
 	if err != nil {
 		return err

--- a/example/stocks/main.go
+++ b/example/stocks/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"image"
 	_ "image/png"
 	"log"
@@ -13,11 +14,15 @@ import (
 
 func main() {
 	var (
-		err error
+		err         error
+		flutter_prj string
 	)
 
+	flag.StringVar(&flutter_prj, "fp", "stocks", "flutter project's filename")
+	flag.Parse()
+
 	options := []gutter.Option{
-		gutter.OptionAssetPath("flutter_project/stocks/build/flutter_assets"),
+		gutter.OptionAssetPath("flutter_project/" + flutter_prj + "/build/flutter_assets"),
 		gutter.OptionICUDataPath("/opt/flutter/bin/cache/artifacts/engine/linux-x64/icudtl.dat"),
 		gutter.OptionWindowInitializer(setIcon),
 	}

--- a/example/stocks/main.go
+++ b/example/stocks/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"image"
 	_ "image/png"
 	"log"
@@ -14,16 +13,12 @@ import (
 
 func main() {
 	var (
-		err         error
-		flutter_prj string
+		err error
 	)
 
-	flag.StringVar(&flutter_prj, "fp", "stocks", "flutter project's filename")
-	flag.Parse()
-
 	options := []gutter.Option{
-		gutter.OptionAssetPath("flutter_project/" + flutter_prj + "/build/flutter_assets"),
-		gutter.OptionICUDataPath("/opt/flutter/bin/cache/artifacts/engine/linux-x64/icudtl.dat"),
+		gutter.OptionAssetPath("flutter_project/stocks/build/flutter_assets"),
+		gutter.OptionICUDataPath("icudtl.dat"),
 		gutter.OptionWindowInitializer(setIcon),
 	}
 

--- a/example/stocks/main.go
+++ b/example/stocks/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"image"
 	_ "image/png"
 	"log"
@@ -13,11 +14,15 @@ import (
 
 func main() {
 	var (
-		err error
+		err         error
+		flutter_prj string
 	)
 
+	flag.StringVar(&flutter_prj, "fp", "stocks", "flutter project's filename")
+	flag.Parse()
+
 	options := []gutter.Option{
-		gutter.OptionAssetPath("flutter_project/stocks/build/flutter_assets"),
+		gutter.OptionAssetPath("flutter_project" + flutter_prj + "build/flutter_assets"),
 		gutter.OptionICUDataPath("icudtl.dat"),
 		gutter.OptionWindowInitializer(setIcon),
 		gutter.OptionPixelRatio(1.9),

--- a/flutter/flutter.go
+++ b/flutter/flutter.go
@@ -22,6 +22,9 @@ const (
 	KInvalidArguments      Result = C.kInvalidArguments
 )
 
+// CharExportedType wrap the C char type
+type CharExportedType C.char
+
 // EngineOpenGL corresponds to the C.FlutterEngine with his associated callback's method.
 type EngineOpenGL struct {
 	// Flutter Engine.
@@ -38,8 +41,8 @@ type EngineOpenGL struct {
 	FPlatfromMessage func(message PlatformMessage, window unsafe.Pointer) bool
 
 	// Engine arguments
-	AssetsPath  string
-	IcuDataPath string
+	AssetsPath  *CharExportedType
+	IcuDataPath *CharExportedType
 }
 
 // Run launches the Flutter Engine in a background thread.
@@ -48,10 +51,10 @@ func (flu *EngineOpenGL) Run(window uintptr) Result {
 	globalFlutterOpenGL = *flu
 
 	args := C.FlutterProjectArgs{
-		assets_path:   C.CString(flu.AssetsPath),
+		assets_path:   (*C.char)(flu.AssetsPath),
 		main_path:     C.CString(""),
 		packages_path: C.CString(""),
-		icu_data_path: C.CString(flu.IcuDataPath),
+		icu_data_path: (*C.char)(flu.IcuDataPath),
 	}
 
 	args.struct_size = C.size_t(unsafe.Sizeof(args))

--- a/gutter.go
+++ b/gutter.go
@@ -6,6 +6,8 @@ import (
 	"time"
 	"unsafe"
 
+	"C"
+
 	"github.com/Drakirus/go-flutter-desktop-embedder/flutter"
 	"github.com/go-gl/glfw/v3.2/glfw"
 )
@@ -204,8 +206,8 @@ func runFlutter(window *glfw.Window, assetsPath string, icuDataPath string) *flu
 
 	flutterOGL := flutter.EngineOpenGL{
 		// Engine arguments
-		AssetsPath:  assetsPath,
-		IcuDataPath: icuDataPath,
+		AssetsPath:  (*flutter.CharExportedType)(C.CString(assetsPath)),
+		IcuDataPath: (*flutter.CharExportedType)(C.CString(icuDataPath)),
 		// Render callbacks
 		FMakeCurrent: func(v unsafe.Pointer) bool {
 			w := glfw.GoWindow(v)


### PR DESCRIPTION
Allows the user to execute the program with the flag "-fp=FILENAME" to choose which project they want to run in the embedder. The project must be found in the "flutter_project" folder. If no project is supplied it will default to "stocks". Also, I'm not sure if you want to keep the demo version of the program bc you can just have multiple flutter projects in the same "flutter_project" folder. Just food for thought! :)