### PR TITLE
Rework textModel to use a rune slice for unicode support

### DIFF
--- a/gutter.go
+++ b/gutter.go
@@ -316,7 +316,7 @@ func onPlatformMessage(platMessage flutter.PlatformMessage, window unsafe.Pointe
 			if state.clientID != 0 {
 				editingState := flutter.ArgsEditingState{}
 				json.Unmarshal(message.Args, &editingState)
-				state.word = editingState.Text
+				state.word = []rune(editingState.Text)
 				state.selectionBase = editingState.SelectionBase
 				state.selectionExtent = editingState.SelectionExtent
 			}
@@ -334,7 +334,7 @@ func updateEditingState(window *glfw.Window) {
 	// state.word = "Лайкаа"
 
 	editingState := flutter.ArgsEditingState{
-		Text:                   state.word,
+		Text:                   string(state.word),
 		SelectionAffinity:      "TextAffinity.downstream",
 		SelectionBase:          state.selectionBase,
 		SelectionExtent:        state.selectionExtent,


### PR DESCRIPTION
Strings are poorly suited for working with unicode symbols, since any symbol can be a multicharacter one, and it's really easy to forget about this while performing length/positioning operations.

This commit reworks strings into rune slices. While not as elegant as string ops (and maybe even a little less memory-effecient), it's much easier to work with and less error-prone.

Also fixes an issue where the non-ANSI inputs corrupt text inputs. This is a screenshot of cyrillic "ЗАЛГО" entered into "stocks" example (click FAB to bring up the input shown).

![image](https://user-images.githubusercontent.com/5209166/47620689-0c6fc500-dafe-11e8-9c68-4d202be9bbd8.png)

Love the project so far, hope it grows!
