### PR TITLE
 Avoid unnecessary PlatformMessage copies in plugin callback loop

### DIFF
--- a/example/simpleDemo/main.go
+++ b/example/simpleDemo/main.go
@@ -57,7 +57,7 @@ func setIcon(window *glfw.Window) error {
 
 // Plugin that read the stdin and send the number to the dart side
 func ownPlugin(
-	platMessage flutter.PlatformMessage,
+	platMessage *flutter.PlatformMessage,
 	flutterEngine *flutter.EngineOpenGL,
 	window *glfw.Window,
 ) bool {

--- a/flutter/flutter.go
+++ b/flutter/flutter.go
@@ -48,7 +48,7 @@ type EngineOpenGL struct {
 	FMakeResourceCurrent func(v unsafe.Pointer) bool
 
 	// platform message callback.
-	FPlatfromMessage func(message PlatformMessage, window unsafe.Pointer) bool
+	FPlatfromMessage func(message *PlatformMessage, window unsafe.Pointer) bool
 
 	// Engine arguments
 	PixelRatio  float64
@@ -163,9 +163,9 @@ type Message struct {
 }
 
 // SendPlatformMessage is used to send a PlatformMessage to the Flutter engine.
-func (flu *EngineOpenGL) SendPlatformMessage(Message PlatformMessage) Result {
+func (flu *EngineOpenGL) SendPlatformMessage(Message *PlatformMessage) Result {
 
-	marshalled, err := json.Marshal(Message.Message)
+	marshalled, err := json.Marshal(&Message.Message)
 	if err != nil {
 		panic("Cound not send a message to the flutter engine: Error while creating the JSON")
 	}
@@ -189,7 +189,7 @@ func (flu *EngineOpenGL) SendPlatformMessage(Message PlatformMessage) Result {
 
 // SendPlatformMessageResponse is used to send a message to the Flutter side using the correct ResponseHandle!
 func (flu *EngineOpenGL) SendPlatformMessageResponse(
-	responseTo PlatformMessage,
+	responseTo *PlatformMessage,
 	data []byte,
 ) Result {
 

--- a/flutter/flutter_proxy_glfw.go
+++ b/flutter/flutter_proxy_glfw.go
@@ -22,15 +22,14 @@ func proxy_on_platform_message(message *C.FlutterPlatformMessage, userPointer un
 	if message.message != nil {
 		str := C.GoStringN(C.c_str(message.message), C.int(message.message_size))
 
-		FlutterPlatformMessage := PlatformMessage{}
-
 		messageContent := Message{}
 		json.Unmarshal([]byte(str), &messageContent)
 
-		FlutterPlatformMessage.Message = messageContent
-		FlutterPlatformMessage.Channel = C.GoString(message.channel)
-		FlutterPlatformMessage.ResponseHandle = message.response_handle
-
+		FlutterPlatformMessage := &PlatformMessage{
+			Message:        messageContent,
+			Channel:        C.GoString(message.channel),
+			ResponseHandle: message.response_handle,
+		}
 		return C.bool(flutterEngines[0].FPlatfromMessage(FlutterPlatformMessage, userPointer))
 	}
 	return C.bool(false)

--- a/gutter.go
+++ b/gutter.go
@@ -21,6 +21,7 @@ func Run(options ...Option) (err error) {
 	// The Windows Title Handler and the TextInput handler come by default
 	options = append(options, addHandlerWindowTitle())
 	options = append(options, addHandlerTextInput())
+	options = append(options, addHandlerClipboard())
 
 	c = c.merge(options...)
 

--- a/gutter.go
+++ b/gutter.go
@@ -204,7 +204,7 @@ func runFlutter(window *glfw.Window, c config) *flutter.EngineOpenGL {
 	}
 
 	// PlatformMessage
-	flutterOGL.FPlatfromMessage = func(platMessage flutter.PlatformMessage, window unsafe.Pointer) bool {
+	flutterOGL.FPlatfromMessage = func(platMessage *flutter.PlatformMessage, window unsafe.Pointer) bool {
 		windows := glfw.GoWindow(window)
 
 		hasDispatched := false
@@ -263,7 +263,7 @@ func updateEditingState(window *glfw.Window) {
 		Method: textUpdateStateMethod,
 	}
 
-	var mess = flutter.PlatformMessage{
+	var mess = &flutter.PlatformMessage{
 		Channel: textInputChannel,
 		Message: message,
 	}

--- a/plugin_receiver.go
+++ b/plugin_receiver.go
@@ -8,7 +8,7 @@ import (
 // PluginReceivers do stuff when receiving Message from the Engine,
 // send result with `flutterEngine.SendPlatformMessageResponse`
 type PluginReceivers func(
-	message flutter.PlatformMessage,
+	message *flutter.PlatformMessage,
 	flutterEngine *flutter.EngineOpenGL,
 	window *glfw.Window,
 ) bool

--- a/system_plugins.go
+++ b/system_plugins.go
@@ -20,6 +20,9 @@ const (
 	platformChannel = "flutter/platform"
 	// Args -> struct ArgsAppSwitcherDescription
 	setDescriptionMethod = "SystemChrome.setApplicationSwitcherDescription"
+
+	clipboardSetData = "Clipboard.setData"
+	clipboardGetData = "Clipboard.getData"
 )
 
 // ArgsAppSwitcherDescription Args content
@@ -48,6 +51,44 @@ func addHandlerWindowTitle() Option {
 
 	return OptionAddPluginReceiver(handler, platformChannel)
 
+}
+
+func addHandlerClipboard() Option {
+	handler := func(platMessage flutter.PlatformMessage,
+		flutterEngine *flutter.EngineOpenGL,
+		window *glfw.Window) bool {
+
+		message := platMessage.Message
+		switch message.Method {
+		case clipboardSetData:
+			newClipboard := struct {
+				Text string `json:"text"`
+			}{}
+			json.Unmarshal(message.Args, &newClipboard)
+			window.SetClipboardString(newClipboard.Text)
+		case clipboardGetData:
+			requestedMime := ""
+			json.Unmarshal(message.Args, &requestedMime)
+			if requestedMime == "text/plain" {
+				clipText, _ := window.GetClipboardString()
+
+				retBytes, _ := json.Marshal([]struct {
+					Text string `json:"text"`
+				}{{clipText}})
+
+				flutterEngine.SendPlatformMessageResponse(platMessage, retBytes)
+				return true
+			} else {
+				// log.Printf("Don't know how to acquire type #v from the clipboard", requestedMime)
+			}
+
+		default:
+			// log.Printf("unhandled platform method: %#v\n", platMessage.Message)
+		}
+		return false
+
+	}
+	return OptionAddPluginReceiver(handler, platformChannel)
 }
 
 /////////////////

--- a/system_plugins.go
+++ b/system_plugins.go
@@ -34,11 +34,11 @@ type ArgsAppSwitcherDescription struct {
 func addHandlerWindowTitle() Option {
 
 	var handler PluginReceivers = func(
-		platMessage flutter.PlatformMessage,
+		platMessage *flutter.PlatformMessage,
 		flutterEngine *flutter.EngineOpenGL,
 		window *glfw.Window,
 	) bool {
-		message := platMessage.Message
+		message := &platMessage.Message
 
 		if message.Method == setDescriptionMethod {
 			msgBody := ArgsAppSwitcherDescription{}
@@ -54,11 +54,11 @@ func addHandlerWindowTitle() Option {
 }
 
 func addHandlerClipboard() Option {
-	handler := func(platMessage flutter.PlatformMessage,
+	handler := func(platMessage *flutter.PlatformMessage,
 		flutterEngine *flutter.EngineOpenGL,
 		window *glfw.Window) bool {
 
-		message := platMessage.Message
+		message := &platMessage.Message
 		switch message.Method {
 		case clipboardSetData:
 			newClipboard := struct {
@@ -124,12 +124,12 @@ type argsEditingState struct {
 func addHandlerTextInput() Option {
 
 	var handler PluginReceivers = func(
-		platMessage flutter.PlatformMessage,
+		platMessage *flutter.PlatformMessage,
 		flutterEngine *flutter.EngineOpenGL,
 		window *glfw.Window,
 	) bool {
 
-		message := platMessage.Message
+		message := &platMessage.Message
 
 		switch message.Method {
 		case textInputClientClear:


### PR DESCRIPTION
Reworked `PlatformMessage` propagation to use pointers.

All golang values are passed by value. That means that when you pass a struct to a function, that's about as efficient as passing all of the struct members as parameters, including copying all the 
nested strings.

This might be okay, or even beneficial from GC perspective for small structs such as `PointerEvent`, but is a really bad idea when used in loops (such as callback loop made by the plugin system).

The only reason you don't see much of pointers in golang stdlib is, it primarily operates on interfaces, while the interfaces themselves are mostly implemented on pointer, not value types.

Also reworked access to `PlatformMessage.Message` into pointers, for the same reason. No need to change the member itself into pointer -- it's only meaningful to pass with the corresponding `PlatformMessage`.