### PR TITLE
Update BUG.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -32,8 +32,8 @@ Golang's compiling errors
 ## Does the prebuilt and portable version works ?
 
 ###### Download [Link](https://github.com/Drakirus/go-flutter-desktop-embedder/releases)
- - [x] Yes
- - [ ] No
+ <!-- Please answer either yes or no -->
+ - Yes / No
 
 ## Steps to Reproduce
 


### PR DESCRIPTION
When referring to an issue created with the template, GitHub shows a "1 of 2 tasks completed" subtitle because of the yes/no question. 

### Example screenshot: 
![selection_074](https://user-images.githubusercontent.com/564501/52902376-066a3500-3210-11e9-9303-dd30b13f8e9a.png)

That's a bit odd. This removes the "task list" from the template.