### PR TITLE
Fix two race conditions and a type conversion mistake

### DIFF
--- a/flutter/flutter_proxy_glfw.go
+++ b/flutter/flutter_proxy_glfw.go
@@ -18,7 +18,7 @@ import (
 // C proxies
 
 //export proxy_on_platform_message
-func proxy_on_platform_message(message *C.FlutterPlatformMessage, userPointer unsafe.Pointer) C.bool {
+func proxy_on_platform_message(message *C.FlutterPlatformMessage, window unsafe.Pointer) C.bool {
 	if message.message != nil {
 		str := C.GoStringN(C.c_str(message.message), C.int(message.message_size))
 
@@ -30,43 +30,49 @@ func proxy_on_platform_message(message *C.FlutterPlatformMessage, userPointer un
 			Channel:        C.GoString(message.channel),
 			ResponseHandle: message.response_handle,
 		}
-		return C.bool(flutterEngines[0].FPlatfromMessage(FlutterPlatformMessage, userPointer))
+		index := *(*int)(glfw.GoWindow(window).GetUserPointer())
+		engine := SelectEngine(index)
+		return C.bool(engine.FPlatfromMessage(FlutterPlatformMessage, window))
 	}
 	return C.bool(false)
-
 }
 
 //export proxy_make_current
 func proxy_make_current(v unsafe.Pointer) C.bool {
 	w := glfw.GoWindow(v)
-	index := *(*C.int)(w.GetUserPointer())
-	return C.bool(flutterEngines[index].FMakeCurrent(v))
+	index := *(*int)(w.GetUserPointer())
+	engine := SelectEngine(index)
+	return C.bool(engine.FMakeCurrent(v))
 }
 
 //export proxy_clear_current
 func proxy_clear_current(v unsafe.Pointer) C.bool {
 	w := glfw.GoWindow(v)
-	index := *(*C.int)(w.GetUserPointer())
-	return C.bool(flutterEngines[index].FClearCurrent(v))
+	index := *(*int)(w.GetUserPointer())
+	engine := SelectEngine(index)
+	return C.bool(engine.FClearCurrent(v))
 }
 
 //export proxy_present
 func proxy_present(v unsafe.Pointer) C.bool {
 	w := glfw.GoWindow(v)
-	index := *(*C.int)(w.GetUserPointer())
-	return C.bool(flutterEngines[index].FPresent(v))
+	index := *(*int)(w.GetUserPointer())
+	engine := SelectEngine(index)
+	return C.bool(engine.FPresent(v))
 }
 
 //export proxy_fbo_callback
 func proxy_fbo_callback(v unsafe.Pointer) C.uint32_t {
 	w := glfw.GoWindow(v)
-	index := *(*C.int)(w.GetUserPointer())
-	return C.uint32_t(flutterEngines[index].FFboCallback(v))
+	index := *(*int)(w.GetUserPointer())
+	engine := SelectEngine(index)
+	return C.uint32_t(engine.FFboCallback(v))
 }
 
 //export proxy_make_resource_current
 func proxy_make_resource_current(v unsafe.Pointer) C.bool {
 	w := glfw.GoWindow(v)
-	index := *(*C.int)(w.GetUserPointer())
-	return C.bool(flutterEngines[index].FMakeResourceCurrent(v))
+	index := *(*int)(w.GetUserPointer())
+	engine := SelectEngine(index)
+	return C.bool(engine.FMakeResourceCurrent(v))
 }


### PR DESCRIPTION
**I have not tested these changes, please test before merging**
Sadly I cannot test due to #68 
The code compiles and I've looked over the changes 5 times. But please test the changes before merging!

This PR fixes two race conditions which may occur when multiple engines are created at the same time.
- The first concerns access around the global slice `flutterEngines`. When appended to from multiple goroutines simultaniously, one append may be overwritten by the other.
- The second concerns the obtaining of index in gutter.go:235. Because the len() and append() operations to the flutterEngines slice are not occurring in a locked transaction, and because the index is appointed before the slice is actually grown. Two goroutines may read len() to be 0, which they use as the index by settings glfw window userdata. Then both engines are started (.Run()). Only at that time are the engines added to the `flutterEngines` slice, causing it to growing two times. The first engine gets the correct index in the slice (0), the second engine gets index 1 in the slice. The GLFW window for the second engine has index 0 in the user data. Chaos occurs. :smile: 

Then, I also found some type inconsistencies. The GLFW window userdata is set to a pointer to a go integer. But when read they are cast to *C.int. I'm not sure if it breaks anything, but it seems wrong, so I've change the types. 

Perhaps one of these changes is related to #32 ?