### PR TITLE
godoc: Handle doc 'MissingPluginException'

### DIFF
--- a/plugin/basic-message-channel.go
+++ b/plugin/basic-message-channel.go
@@ -78,7 +78,8 @@ func (b *BasicMessageChannel) Send(message interface{}) (reply interface{}, err 
 // of) this channel.
 //
 // When given nil as handler, any incoming message on this channel will be
-// handled silently by sending a nil reply (null on the dart side).
+// handled silently by sending a nil reply which triggers
+// the dart MissingPluginException exception.
 func (b *BasicMessageChannel) Handle(handler BasicMessageHandler) {
 	b.handler = handler
 }

--- a/plugin/method-channel.go
+++ b/plugin/method-channel.go
@@ -81,8 +81,9 @@ func (m *MethodChannel) InvokeMethod(name string, arguments interface{}) (result
 // of) this channel. When given nil as handler, the previously registered
 // handler for a method is unregistrered.
 //
-// When no handler is registered for a method, it will be handled silently by
-// sending a nil reply (null on the dart side).
+// When no handler is registered for a method, it will be
+// handled silently by sending a nil reply which triggers
+// the dart MissingPluginException exception.
 func (m *MethodChannel) Handle(methodName string, handler MethodHandler) {
 	m.methodsLock.Lock()
 	if handler == nil {


### PR DESCRIPTION
Update go-doc of Channels.
`null` isn't send to the dart side but an `MissingPluginException` is raised.