### PR TITLE
Added support for Delete shortcuts

### DIFF
--- a/textinput.go
+++ b/textinput.go
@@ -166,5 +166,6 @@ func (p *textinputPlugin) glfwKeyCallback(window *glfw.Window, key glfw.Key, sca
 				p.addChar([]rune(clpString))
 			}
 		}
+		p.updateEditingState()
 	}
 }

--- a/textinput.go
+++ b/textinput.go
@@ -31,7 +31,7 @@ type textinputPlugin struct {
 }
 
 type keyboardShortcutsGLFW struct {
-    mod    glfw.ModifierKey
+	mod glfw.ModifierKey
 }
 
 // all hardcoded because theres not pluggable renderer system.
@@ -140,20 +140,20 @@ func (p *textinputPlugin) glfwKeyCallback(window *glfw.Window, key glfw.Key, sca
 
 		case p.keyboardLayout.SelectAll:
 			if keyboardShortcutBind.isModifier() {
-				p.SelectAll()
+				p.selectAll()
 			}
 
 		case p.keyboardLayout.Copy:
 			if keyboardShortcutBind.isModifier() && p.isSelected() {
-				_, _, selectedContent := p.GetSelectedText()
+				_, _, selectedContent := p.getSelectedText()
 				window.SetClipboardString(selectedContent)
 			}
 
 		case p.keyboardLayout.Cut:
 			if keyboardShortcutBind.isModifier() && p.isSelected() {
-				_, _, selectedContent := p.GetSelectedText()
+				_, _, selectedContent := p.getSelectedText()
 				window.SetClipboardString(selectedContent)
-				p.RemoveSelectedText()
+				p.removeSelectedText()
 			}
 
 		case p.keyboardLayout.Paste:

--- a/textinput.go
+++ b/textinput.go
@@ -30,6 +30,7 @@ type textinputPlugin struct {
 	selectionExtent int
 }
 
+// keyboardShortcutsGLFW handle glfw.ModifierKey from glfwKeyCallback.
 type keyboardShortcutsGLFW struct {
 	mod glfw.ModifierKey
 }

--- a/textinput.go
+++ b/textinput.go
@@ -3,7 +3,6 @@ package flutter
 import (
 	"encoding/json"
 	"fmt"
-	"runtime"
 
 	"github.com/go-flutter-desktop/go-flutter/plugin"
 	"github.com/go-gl/glfw/v3.2/glfw"
@@ -31,6 +30,10 @@ type textinputPlugin struct {
 	selectionExtent int
 }
 
+type keyboardShortcutsGLFW struct {
+    mod    glfw.ModifierKey
+}
+
 // all hardcoded because theres not pluggable renderer system.
 var defaultTextinputPlugin = &textinputPlugin{}
 
@@ -39,18 +42,6 @@ var _ PluginGLFW = &textinputPlugin{} // compile-time type check
 
 func (p *textinputPlugin) InitPlugin(messenger plugin.BinaryMessenger) error {
 	p.messenger = messenger
-
-	// set modifier keys based on OS
-	switch runtime.GOOS {
-	case "darwin":
-		p.modifierKey = glfw.ModSuper
-		p.wordTravellerKey = glfw.ModAlt
-		p.wordTravellerKeyShift = glfw.ModAlt | glfw.ModShift
-	default:
-		p.modifierKey = glfw.ModControl
-		p.wordTravellerKey = glfw.ModControl
-		p.wordTravellerKeyShift = glfw.ModControl | glfw.ModShift
-	}
 
 	return nil
 }
@@ -105,22 +96,8 @@ func (p *textinputPlugin) glfwCharCallback(w *glfw.Window, char rune) {
 }
 
 func (p *textinputPlugin) glfwKeyCallback(window *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
-	var modsIsModfifier = false
-	var modsIsShift = false
-	var modsIsWordModifierShift = false
-	var modsIsWordModifier = false
 
-	switch {
-	case mods == p.wordTravellerKeyShift:
-		modsIsWordModifierShift = true
-	case mods == p.wordTravellerKey:
-		modsIsWordModifier = true
-	case mods == p.modifierKey:
-		modsIsModfifier = true
-	case mods == glfw.ModShift:
-		modsIsShift = true
-	}
-
+	keyboardShortcutBind := keyboardShortcutsGLFW{mod: mods}
 	if key == glfw.KeyEscape && action == glfw.Press {
 		_, err := defaultNavigationPlugin.channel.InvokeMethod("popRoute", nil)
 		if err != nil {
@@ -144,43 +121,43 @@ func (p *textinputPlugin) glfwKeyCallback(window *glfw.Window, key glfw.Key, sca
 			}
 
 		case glfw.KeyHome:
-			p.MoveCursorHome(modsIsModfifier, modsIsShift, modsIsWordModifierShift, modsIsWordModifier)
+			p.MoveCursorHome(keyboardShortcutBind)
 
 		case glfw.KeyEnd:
-			p.MoveCursorEnd(modsIsModfifier, modsIsShift, modsIsWordModifierShift, modsIsWordModifier)
+			p.MoveCursorEnd(keyboardShortcutBind)
 
 		case glfw.KeyLeft:
-			p.MoveCursorLeft(modsIsModfifier, modsIsShift, modsIsWordModifierShift, modsIsWordModifier)
+			p.MoveCursorLeft(keyboardShortcutBind)
 
 		case glfw.KeyRight:
-			p.MoveCursorRight(modsIsModfifier, modsIsShift, modsIsWordModifierShift, modsIsWordModifier)
+			p.MoveCursorRight(keyboardShortcutBind)
 
 		case glfw.KeyDelete:
-			p.Delete(modsIsModfifier, modsIsShift, modsIsWordModifierShift, modsIsWordModifier)
+			p.Delete(keyboardShortcutBind)
 
 		case glfw.KeyBackspace:
-			p.Backspace(modsIsModfifier, modsIsShift, modsIsWordModifierShift, modsIsWordModifier)
+			p.Backspace(keyboardShortcutBind)
 
 		case p.keyboardLayout.SelectAll:
-			if mods == p.modifierKey {
+			if keyboardShortcutBind.isModifier() {
 				p.SelectAll()
 			}
 
 		case p.keyboardLayout.Copy:
-			if mods == p.modifierKey && p.isSelected() {
+			if keyboardShortcutBind.isModifier() && p.isSelected() {
 				_, _, selectedContent := p.GetSelectedText()
 				window.SetClipboardString(selectedContent)
 			}
 
 		case p.keyboardLayout.Cut:
-			if mods == p.modifierKey && p.isSelected() {
+			if keyboardShortcutBind.isModifier() && p.isSelected() {
 				_, _, selectedContent := p.GetSelectedText()
 				window.SetClipboardString(selectedContent)
 				p.RemoveSelectedText()
 			}
 
 		case p.keyboardLayout.Paste:
-			if mods == p.modifierKey {
+			if keyboardShortcutBind.isModifier() {
 				var clpString, err = window.GetClipboardString()
 				if err != nil {
 					fmt.Printf("go-flutter: unable to get the clipboard content: %v\n", err)

--- a/textinput_darwin.go
+++ b/textinput_darwin.go
@@ -1,0 +1,92 @@
+package flutter
+
+import (
+	"github.com/go-gl/glfw/v3.2/glfw"
+)
+
+func (p *keyboardShortcutsGLFW) isModifier() bool {
+	return p.mod & glfw.ModSuper != 0
+}
+
+func (p *keyboardShortcutsGLFW) isShift() bool {
+	return p.mod & glfw.ModShift != 0
+}
+
+func (p *keyboardShortcutsGLFW) isWordTravel() bool {
+	return p.mod & glfw.ModAlt != 0
+}
+
+func (p *keyboardShortcutsGLFW) isWordTravelShift() bool {
+	return p.mod & glfw.ModAlt != 0 && p.mod & glfw.ModShift != 0
+}
+
+func (p *textinputPlugin) MoveCursorHome(mods keyboardShortcutsGLFW) {
+
+	if mods.isShift(){
+		p.MoveCursorHomeSelect()
+	} else {
+		p.MoveCursorHomeSimple()
+	}
+}
+
+func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
+	if mods.isShift() {
+		p.MoveCursorEndSelect()
+	} else {
+		p.MoveCursorEndSimple()
+	}
+}
+
+func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
+	if mods.isWordTravelShift() {
+		p.MoveCursorLeftLine()
+	} else if mods.isWordTravel() {
+		p.MoveCursorLeftWord()		
+	} else if mods.isShift() {
+		p.MoveCursorLeftSimple()
+	} else {
+		p.MoveCursorLeftReset()
+	}
+}
+
+func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
+	if mods.isWordTravelShift() {
+		p.MoveCursorRightLine()
+	} else if mods.isWordTravel() {
+		p.MoveCursorRightWord()		
+	} else if mods.isShift() {
+		p.MoveCursorRightSimple()
+	} else {
+		p.MoveCursorRightReset()
+	}
+}
+
+func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
+	if p.RemoveSelectedText() {
+		p.updateEditingState()
+		return
+	}
+
+	if mods.isModifier() {
+		p.BackspaceLine()
+	} else if mods.isWordTravel() {
+		p.BackspaceWord()
+	} else {
+		p.BackspaceSimple()
+	}
+}
+
+func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
+	if p.RemoveSelectedText() {
+		p.updateEditingState()
+		return
+	}
+
+	if mods.isWordTravelShift() {
+		p.DeleteLine()
+	} else if mods.isWordTravel() {
+		p.DeleteWord()
+	} else {
+		p.DeleteSimple()
+	}
+}

--- a/textinput_darwin.go
+++ b/textinput_darwin.go
@@ -21,17 +21,17 @@ func (p *keyboardShortcutsGLFW) isWordTravelShift() bool {
 func (p *textinputPlugin) MoveCursorHome(mods keyboardShortcutsGLFW) {
 
 	if mods.isShift() {
-		p.MoveCursorHomeSelect()
+		p.moveCursorHomeSelect()
 	} else {
-		p.MoveCursorHomeSimple()
+		p.moveCursorHomeSimple()
 	}
 }
 
 func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 	if mods.isShift() {
-		p.MoveCursorEndSelect()
+		p.moveCursorEndSelect()
 	} else {
-		p.MoveCursorEndSimple()
+		p.moveCursorEndSimple()
 	}
 }
 
@@ -66,9 +66,9 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 	}
 
 	if mods.isModifier() {
-		p.BackspaceLine()
+		p.backspaceLine()
 	} else if mods.isWordTravel() {
-		p.BackspaceWord()
+		p.backspaceWord()
 	} else {
 		p.backspaceChar()
 	}
@@ -81,9 +81,9 @@ func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
 	}
 
 	if mods.isWordTravelShift() {
-		p.DeleteLine()
+		p.deleteLine()
 	} else if mods.isWordTravel() {
-		p.DeleteWord()
+		p.deleteWord()
 	} else {
 		p.deleteChar()
 	}

--- a/textinput_darwin.go
+++ b/textinput_darwin.go
@@ -37,25 +37,25 @@ func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 
 func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.MoveCursorLeftLine()
+		p.extentSelectionLineLeft()
 	} else if mods.isWordTravel() {
-		p.MoveCursorLeftWord()
+		p.extentSelectionWordLeft()
 	} else if mods.isShift() {
-		p.MoveCursorLeftSimple()
+		p.extentSelectionCharLeft()
 	} else {
-		p.MoveCursorLeftReset()
+		p.extentSelectionResetLeft()
 	}
 }
 
 func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.MoveCursorRightLine()
+		p.extentSelectionLineRight()
 	} else if mods.isWordTravel() {
-		p.MoveCursorRightWord()
+		p.extentSelectionWordRight()
 	} else if mods.isShift() {
-		p.MoveCursorRightSimple()
+		p.extentSelectionCharRight()
 	} else {
-		p.MoveCursorRightReset()
+		p.extentSelectionResetRight()
 	}
 }
 
@@ -70,7 +70,7 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 	} else if mods.isWordTravel() {
 		p.BackspaceWord()
 	} else {
-		p.BackspaceSimple()
+		p.backspaceChar()
 	}
 }
 
@@ -85,6 +85,6 @@ func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
 	} else if mods.isWordTravel() {
 		p.DeleteWord()
 	} else {
-		p.DeleteSimple()
+		p.deleteChar()
 	}
 }

--- a/textinput_darwin.go
+++ b/textinput_darwin.go
@@ -37,25 +37,25 @@ func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 
 func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.extentSelectionLineLeft()
+		p.extentSelectionLeftLine()
 	} else if mods.isWordTravel() {
-		p.extentSelectionWordLeft()
+		p.extentSelectionLeftWord()
 	} else if mods.isShift() {
-		p.extentSelectionCharLeft()
+		p.extentSelectionLeftChar()
 	} else {
-		p.extentSelectionResetLeft()
+		p.extentSelectionLeftReset()
 	}
 }
 
 func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.extentSelectionLineRight()
+		p.extentSelectionRightLine()
 	} else if mods.isWordTravel() {
-		p.extentSelectionWordRight()
+		p.extentSelectionRightWord()
 	} else if mods.isShift() {
-		p.extentSelectionCharRight()
+		p.extentSelectionRightChar()
 	} else {
-		p.extentSelectionResetRight()
+		p.extentSelectionRightReset()
 	}
 }
 
@@ -66,11 +66,11 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 	}
 
 	if mods.isModifier() {
-		p.backspaceLine()
+		p.sliceLeftLine()
 	} else if mods.isWordTravel() {
-		p.backspaceWord()
+		p.sliceLeftWord()
 	} else {
-		p.backspaceChar()
+		p.sliceLeftChar()
 	}
 }
 
@@ -81,10 +81,10 @@ func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
 	}
 
 	if mods.isWordTravelShift() {
-		p.deleteLine()
+		p.sliceRightLine()
 	} else if mods.isWordTravel() {
-		p.deleteWord()
+		p.sliceRightWord()
 	} else {
-		p.deleteChar()
+		p.sliceRightChar()
 	}
 }

--- a/textinput_darwin.go
+++ b/textinput_darwin.go
@@ -1,28 +1,26 @@
 package flutter
 
-import (
-	"github.com/go-gl/glfw/v3.2/glfw"
-)
+import "github.com/go-gl/glfw/v3.2/glfw"
 
 func (p *keyboardShortcutsGLFW) isModifier() bool {
-	return p.mod & glfw.ModSuper != 0
+	return p.mod&glfw.ModSuper != 0
 }
 
 func (p *keyboardShortcutsGLFW) isShift() bool {
-	return p.mod & glfw.ModShift != 0
+	return p.mod&glfw.ModShift != 0
 }
 
 func (p *keyboardShortcutsGLFW) isWordTravel() bool {
-	return p.mod & glfw.ModAlt != 0
+	return p.mod&glfw.ModAlt != 0
 }
 
 func (p *keyboardShortcutsGLFW) isWordTravelShift() bool {
-	return p.mod & glfw.ModAlt != 0 && p.mod & glfw.ModShift != 0
+	return p.mod&glfw.ModAlt != 0 && p.mod&glfw.ModShift != 0
 }
 
 func (p *textinputPlugin) MoveCursorHome(mods keyboardShortcutsGLFW) {
 
-	if mods.isShift(){
+	if mods.isShift() {
 		p.MoveCursorHomeSelect()
 	} else {
 		p.MoveCursorHomeSimple()
@@ -41,7 +39,7 @@ func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
 		p.MoveCursorLeftLine()
 	} else if mods.isWordTravel() {
-		p.MoveCursorLeftWord()		
+		p.MoveCursorLeftWord()
 	} else if mods.isShift() {
 		p.MoveCursorLeftSimple()
 	} else {
@@ -53,7 +51,7 @@ func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
 		p.MoveCursorRightLine()
 	} else if mods.isWordTravel() {
-		p.MoveCursorRightWord()		
+		p.MoveCursorRightWord()
 	} else if mods.isShift() {
 		p.MoveCursorRightSimple()
 	} else {

--- a/textinput_darwin.go
+++ b/textinput_darwin.go
@@ -23,7 +23,7 @@ func (p *textinputPlugin) MoveCursorHome(mods keyboardShortcutsGLFW) {
 	if mods.isShift() {
 		p.moveCursorHomeSelect()
 	} else {
-		p.moveCursorHomeSimple()
+		p.moveCursorHomeNoSelect()
 	}
 }
 
@@ -31,7 +31,7 @@ func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 	if mods.isShift() {
 		p.moveCursorEndSelect()
 	} else {
-		p.moveCursorEndSimple()
+		p.moveCursorEndNoSelect()
 	}
 }
 

--- a/textinput_darwin.go
+++ b/textinput_darwin.go
@@ -37,25 +37,25 @@ func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 
 func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.extentSelectionLeftLine()
+		p.extendSelectionLeftLine()
 	} else if mods.isWordTravel() {
-		p.extentSelectionLeftWord()
+		p.extendSelectionLeftWord()
 	} else if mods.isShift() {
-		p.extentSelectionLeftChar()
+		p.extendSelectionLeftChar()
 	} else {
-		p.extentSelectionLeftReset()
+		p.extendSelectionLeftReset()
 	}
 }
 
 func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.extentSelectionRightLine()
+		p.extendSelectionRightLine()
 	} else if mods.isWordTravel() {
-		p.extentSelectionRightWord()
+		p.extendSelectionRightWord()
 	} else if mods.isShift() {
-		p.extentSelectionRightChar()
+		p.extendSelectionRightChar()
 	} else {
-		p.extentSelectionRightReset()
+		p.extendSelectionRightReset()
 	}
 }
 

--- a/textinput_darwin.go
+++ b/textinput_darwin.go
@@ -60,7 +60,7 @@ func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 }
 
 func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
-	if p.RemoveSelectedText() {
+	if p.removeSelectedText() {
 		p.updateEditingState()
 		return
 	}
@@ -75,7 +75,7 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 }
 
 func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
-	if p.RemoveSelectedText() {
+	if p.removeSelectedText() {
 		p.updateEditingState()
 		return
 	}

--- a/textinput_linux.go
+++ b/textinput_linux.go
@@ -64,7 +64,7 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 		return
 	}
 
-	if mods.isModifier() {
+	if mods.isWordTravelShift() {
 		p.sliceLeftLine()
 	} else if mods.isWordTravel() {
 		p.sliceLeftWord()

--- a/textinput_linux.go
+++ b/textinput_linux.go
@@ -59,7 +59,7 @@ func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 }
 
 func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
-	if p.RemoveSelectedText() {
+	if p.removeSelectedText() {
 		p.updateEditingState()
 		return
 	}
@@ -74,7 +74,7 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 }
 
 func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
-	if p.RemoveSelectedText() {
+	if p.removeSelectedText() {
 		p.updateEditingState()
 		return
 	}

--- a/textinput_linux.go
+++ b/textinput_linux.go
@@ -36,25 +36,25 @@ func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 
 func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.MoveCursorLeftLine()
+		p.extentSelectionLineLeft()
 	} else if mods.isWordTravel() {
-		p.MoveCursorLeftWord()
+		p.extentSelectionWordLeft()
 	} else if mods.isShift() {
-		p.MoveCursorLeftSimple()
+		p.extentSelectionCharLeft()
 	} else {
-		p.MoveCursorLeftReset()
+		p.extentSelectionResetLeft()
 	}
 }
 
 func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.MoveCursorRightLine()
+		p.extentSelectionLineRight()
 	} else if mods.isWordTravel() {
-		p.MoveCursorRightWord()
+		p.extentSelectionWordRight()
 	} else if mods.isShift() {
-		p.MoveCursorRightSimple()
+		p.extentSelectionCharRight()
 	} else {
-		p.MoveCursorRightReset()
+		p.extentSelectionResetRight()
 	}
 }
 
@@ -69,7 +69,7 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 	} else if mods.isWordTravel() {
 		p.BackspaceWord()
 	} else {
-		p.BackspaceSimple()
+		p.backspaceChar()
 	}
 }
 
@@ -84,6 +84,6 @@ func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
 	} else if mods.isWordTravel() {
 		p.DeleteWord()
 	} else {
-		p.DeleteSimple()
+		p.deleteChar()
 	}
 }

--- a/textinput_linux.go
+++ b/textinput_linux.go
@@ -22,7 +22,7 @@ func (p *textinputPlugin) MoveCursorHome(mods keyboardShortcutsGLFW) {
 	if mods.isShift() {
 		p.moveCursorHomeSelect()
 	} else {
-		p.moveCursorHomeSimple()
+		p.moveCursorHomeNoSelect()
 	}
 }
 
@@ -30,7 +30,7 @@ func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 	if mods.isShift() {
 		p.moveCursorEndSelect()
 	} else {
-		p.moveCursorEndSimple()
+		p.moveCursorEndNoSelect()
 	}
 }
 

--- a/textinput_linux.go
+++ b/textinput_linux.go
@@ -20,17 +20,17 @@ func (p *keyboardShortcutsGLFW) isWordTravelShift() bool {
 
 func (p *textinputPlugin) MoveCursorHome(mods keyboardShortcutsGLFW) {
 	if mods.isShift() {
-		p.MoveCursorHomeSelect()
+		p.moveCursorHomeSelect()
 	} else {
-		p.MoveCursorHomeSimple()
+		p.moveCursorHomeSimple()
 	}
 }
 
 func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 	if mods.isShift() {
-		p.MoveCursorEndSelect()
+		p.moveCursorEndSelect()
 	} else {
-		p.MoveCursorEndSimple()
+		p.moveCursorEndSimple()
 	}
 }
 
@@ -65,9 +65,9 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 	}
 
 	if mods.isModifier() {
-		p.BackspaceLine()
+		p.backspaceLine()
 	} else if mods.isWordTravel() {
-		p.BackspaceWord()
+		p.backspaceWord()
 	} else {
 		p.backspaceChar()
 	}
@@ -80,9 +80,9 @@ func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
 	}
 
 	if mods.isWordTravelShift() {
-		p.DeleteLine()
+		p.deleteLine()
 	} else if mods.isWordTravel() {
-		p.DeleteWord()
+		p.deleteWord()
 	} else {
 		p.deleteChar()
 	}

--- a/textinput_linux.go
+++ b/textinput_linux.go
@@ -36,25 +36,25 @@ func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 
 func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.extentSelectionLeftLine()
+		p.extendSelectionLeftLine()
 	} else if mods.isWordTravel() {
-		p.extentSelectionLeftWord()
+		p.extendSelectionLeftWord()
 	} else if mods.isShift() {
-		p.extentSelectionLeftChar()
+		p.extendSelectionLeftChar()
 	} else {
-		p.extentSelectionLeftReset()
+		p.extendSelectionLeftReset()
 	}
 }
 
 func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.extentSelectionRightLine()
+		p.extendSelectionRightLine()
 	} else if mods.isWordTravel() {
-		p.extentSelectionRightWord()
+		p.extendSelectionRightWord()
 	} else if mods.isShift() {
-		p.extentSelectionRightChar()
+		p.extendSelectionRightChar()
 	} else {
-		p.extentSelectionRightReset()
+		p.extendSelectionRightReset()
 	}
 }
 

--- a/textinput_linux.go
+++ b/textinput_linux.go
@@ -1,0 +1,87 @@
+package flutter
+
+func (p *keyboardShortcutsGLFW) isModifier() bool {
+	return p.mod & glfw.ModControl != 0
+}
+
+func (p *keyboardShortcutsGLFW) isShift() bool {
+	return p.mod & glfw.ModShift != 0
+}
+
+func (p *keyboardShortcutsGLFW) isWordTravel() bool {
+	return p.mod & glfw.ModControl != 0
+}
+
+func (p *keyboardShortcutsGLFW) isWordTravelShift() bool {
+	return p.mod & glfw.ModControl != 0 && p.mod & glfw.ModShift != 0
+}
+
+func (p *textinputPlugin) MoveCursorHome(mods keyboardShortcutsGLFW) {
+	if mods.isShift() {
+		p.MoveCursorHomeSelect()
+	} else {
+		p.MoveCursorHomeSimple()
+	}
+}
+
+func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
+	if mods.isShift() {
+		p.MoveCursorEndSelect()
+	} else {
+		p.MoveCursorEndSimple()
+	}
+}
+
+func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
+	if mods.isWordTravelShift() {
+		p.MoveCursorLeftLine()
+	} else if mods.isWordTravel() {
+		p.MoveCursorLeftWord()		
+	} else if mods.isShift() {
+		p.MoveCursorLeftSimple()
+	} else {
+		p.MoveCursorLeftReset()
+	}
+}
+
+func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
+	if mods.isWordTravelShift() {
+		p.MoveCursorRightLine()
+	} else if mods.isWordTravel() {
+		p.MoveCursorRightWord()		
+	} else if mods.isShift() {
+		p.MoveCursorRightSimple()
+	} else {
+		p.MoveCursorRightReset()
+	}
+}
+
+func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
+	if p.RemoveSelectedText() {
+		p.updateEditingState()
+		return
+	}
+
+	if mods.isModifier() {
+		p.BackspaceLine()
+	} else if mods.isWordTravel() {
+		p.BackspaceWord()
+	} else {
+		p.BackspaceSimple()
+	}
+}
+
+func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
+	if p.RemoveSelectedText() {
+		p.updateEditingState()
+		return
+	}
+
+	if mods.isWordTravelShift() {
+		p.DeleteLine()
+	} else if mods.isWordTravel() {
+		p.DeleteWord()
+	} else {
+		p.DeleteSimple()
+	}
+}

--- a/textinput_linux.go
+++ b/textinput_linux.go
@@ -1,19 +1,21 @@
 package flutter
 
+import "github.com/go-gl/glfw/v3.2/glfw"
+
 func (p *keyboardShortcutsGLFW) isModifier() bool {
-	return p.mod & glfw.ModControl != 0
+	return p.mod&glfw.ModControl != 0
 }
 
 func (p *keyboardShortcutsGLFW) isShift() bool {
-	return p.mod & glfw.ModShift != 0
+	return p.mod&glfw.ModShift != 0
 }
 
 func (p *keyboardShortcutsGLFW) isWordTravel() bool {
-	return p.mod & glfw.ModControl != 0
+	return p.mod&glfw.ModControl != 0
 }
 
 func (p *keyboardShortcutsGLFW) isWordTravelShift() bool {
-	return p.mod & glfw.ModControl != 0 && p.mod & glfw.ModShift != 0
+	return p.mod&glfw.ModControl != 0 && p.mod&glfw.ModShift != 0
 }
 
 func (p *textinputPlugin) MoveCursorHome(mods keyboardShortcutsGLFW) {
@@ -36,7 +38,7 @@ func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
 		p.MoveCursorLeftLine()
 	} else if mods.isWordTravel() {
-		p.MoveCursorLeftWord()		
+		p.MoveCursorLeftWord()
 	} else if mods.isShift() {
 		p.MoveCursorLeftSimple()
 	} else {
@@ -48,7 +50,7 @@ func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
 		p.MoveCursorRightLine()
 	} else if mods.isWordTravel() {
-		p.MoveCursorRightWord()		
+		p.MoveCursorRightWord()
 	} else if mods.isShift() {
 		p.MoveCursorRightSimple()
 	} else {

--- a/textinput_linux.go
+++ b/textinput_linux.go
@@ -36,25 +36,25 @@ func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 
 func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.extentSelectionLineLeft()
+		p.extentSelectionLeftLine()
 	} else if mods.isWordTravel() {
-		p.extentSelectionWordLeft()
+		p.extentSelectionLeftWord()
 	} else if mods.isShift() {
-		p.extentSelectionCharLeft()
+		p.extentSelectionLeftChar()
 	} else {
-		p.extentSelectionResetLeft()
+		p.extentSelectionLeftReset()
 	}
 }
 
 func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.extentSelectionLineRight()
+		p.extentSelectionRightLine()
 	} else if mods.isWordTravel() {
-		p.extentSelectionWordRight()
+		p.extentSelectionRightWord()
 	} else if mods.isShift() {
-		p.extentSelectionCharRight()
+		p.extentSelectionRightChar()
 	} else {
-		p.extentSelectionResetRight()
+		p.extentSelectionRightReset()
 	}
 }
 
@@ -65,11 +65,11 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 	}
 
 	if mods.isModifier() {
-		p.backspaceLine()
+		p.sliceLeftLine()
 	} else if mods.isWordTravel() {
-		p.backspaceWord()
+		p.sliceLeftWord()
 	} else {
-		p.backspaceChar()
+		p.sliceLeftChar()
 	}
 }
 
@@ -80,10 +80,10 @@ func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
 	}
 
 	if mods.isWordTravelShift() {
-		p.deleteLine()
+		p.sliceRightLine()
 	} else if mods.isWordTravel() {
-		p.deleteWord()
+		p.sliceRightWord()
 	} else {
-		p.deleteChar()
+		p.sliceRightChar()
 	}
 }

--- a/textinput_model.go
+++ b/textinput_model.go
@@ -33,35 +33,52 @@ func (p *textinputPlugin) addChar(char []rune) {
 	p.updateEditingState()
 }
 
-func (p *textinputPlugin) MoveCursorHome(modsIsModifier bool, modsIsShift bool, modsIsWordModifierShift bool, modsIsWordModifier bool) {
+func (p *textinputPlugin) MoveCursorHomeSimple() {
 	p.selectionBase = 0
-	if !modsIsShift {
-		p.selectionExtent = p.selectionBase
-	}
+	p.selectionExtent = p.selectionBase
 	p.updateEditingState()
 }
 
-func (p *textinputPlugin) MoveCursorEnd(modsIsModifier bool, modsIsShift bool, modsIsWordModifierShift bool, modsIsWordModifier bool) {
+func (p *textinputPlugin) MoveCursorHomeSelect() {
+	p.selectionBase = 0
+	p.updateEditingState()
+}
+
+func (p *textinputPlugin) MoveCursorEndSimple() {
 	p.selectionBase = len(p.word)
-	if !modsIsShift {
-		p.selectionExtent = p.selectionBase
-	}
+	p.selectionExtent = p.selectionBase
 	p.updateEditingState()
 }
 
-func (p *textinputPlugin) MoveCursorLeft(modsIsModifier bool, modsIsShift bool, modsIsWordModifierShift bool, modsIsWordModifier bool) {
-	if modsIsWordModifierShift {
-		if p.isSelected() {
-			p.selectionExtent = indexStartLeadingWord(p.word, p.selectionExtent)
-		} else {
-			p.selectionExtent = indexStartLeadingWord(p.word, p.selectionBase)
-		}
-	} else if modsIsWordModifier {
-		p.selectionBase = indexStartLeadingWord(p.word, p.selectionBase)
-		p.selectionExtent = p.selectionBase
-	} else if modsIsShift {
-		p.selectionExtent--
-	} else if !p.isSelected() {
+func (p *textinputPlugin) MoveCursorEndSelect() {
+	p.selectionBase = len(p.word)
+	p.updateEditingState()
+}
+
+func (p *textinputPlugin) MoveCursorLeftSimple() {
+	p.selectionExtent--
+	p.updateEditingState()
+}
+
+func (p *textinputPlugin) MoveCursorLeftWord() {
+	p.selectionBase = indexStartLeadingWord(p.word, p.selectionBase)
+	p.selectionExtent = p.selectionBase
+	p.updateEditingState()
+
+}
+
+func (p *textinputPlugin) MoveCursorLeftLine() {
+	if p.isSelected() {
+		p.selectionExtent = indexStartLeadingWord(p.word, p.selectionExtent)
+	} else {
+		p.selectionExtent = indexStartLeadingWord(p.word, p.selectionBase)
+	}
+	p.updateEditingState()
+
+}
+
+func (p *textinputPlugin) MoveCursorLeftReset() {
+	if !p.isSelected() {
 		if p.selectionBase > 0 {
 			p.selectionBase--
 			p.selectionExtent = p.selectionBase
@@ -72,19 +89,30 @@ func (p *textinputPlugin) MoveCursorLeft(modsIsModifier bool, modsIsShift bool, 
 	p.updateEditingState()
 }
 
-func (p *textinputPlugin) MoveCursorRight(modsIsModifier bool, modsIsShift bool, modsIsWordModifierShift bool, modsIsWordModifier bool) {
-	if modsIsWordModifierShift {
-		if p.isSelected() {
-			p.selectionExtent = indexEndForwardWord(p.word, p.selectionExtent)
-		} else {
-			p.selectionExtent = indexEndForwardWord(p.word, p.selectionBase)
-		}
-	} else if modsIsWordModifier {
-		p.selectionBase = indexEndForwardWord(p.word, p.selectionBase)
-		p.selectionExtent = p.selectionBase
-	} else if modsIsShift {
-		p.selectionExtent++
-	} else if !p.isSelected() {
+func (p *textinputPlugin) MoveCursorRightSimple() {
+	p.selectionExtent++
+	p.updateEditingState()
+}
+
+func (p *textinputPlugin) MoveCursorRightWord() {
+	p.selectionBase = indexEndForwardWord(p.word, p.selectionBase)
+	p.selectionExtent = p.selectionBase
+	p.updateEditingState()
+
+}
+
+func (p *textinputPlugin) MoveCursorRightLine() {
+	if p.isSelected() {
+		p.selectionExtent = indexEndForwardWord(p.word, p.selectionExtent)
+	} else {
+		p.selectionExtent = indexEndForwardWord(p.word, p.selectionBase)
+	}
+	p.updateEditingState()
+
+}
+
+func (p *textinputPlugin) MoveCursorRightReset() {
+	if !p.isSelected() {
 		if p.selectionBase < len(p.word) {
 			p.selectionBase++
 			p.selectionExtent = p.selectionBase
@@ -92,9 +120,7 @@ func (p *textinputPlugin) MoveCursorRight(modsIsModifier bool, modsIsShift bool,
 	} else {
 		p.selectionBase = p.selectionExtent
 	}
-
 	p.updateEditingState()
-
 }
 
 func (p *textinputPlugin) SelectAll() {
@@ -103,41 +129,49 @@ func (p *textinputPlugin) SelectAll() {
 	p.updateEditingState()
 }
 
-func (p *textinputPlugin) Delete(modsIsModifier bool, modsIsShift bool, modsIsWordModifierShift bool, modsIsWordModifier bool) {
-	if p.RemoveSelectedText() {
-		p.updateEditingState()
-		return
-	}
-
+func (p *textinputPlugin) DeleteSimple() {
 	if p.selectionBase < len(p.word) {
 		p.word = append(p.word[:p.selectionBase], p.word[p.selectionBase+1:]...)
 		p.updateEditingState()
 	}
 }
 
-func (p *textinputPlugin) Backspace(modsIsModifier bool, modsIsShift bool, modsIsWordModifierShift bool, modsIsWordModifier bool) {
-	if p.RemoveSelectedText() {
-		p.updateEditingState()
-		return
-	}
+func (p *textinputPlugin) DeleteWord() {
+	UpTo := indexEndForwardWord(p.word, p.selectionBase)
+	p.word = append(p.word[:p.selectionBase], p.word[UpTo:]...)
+	p.updateEditingState()
+}
 
+func (p *textinputPlugin) DeleteLine() {
+	p.word = p.word[:p.selectionBase]
+	p.updateEditingState()
+}
+
+
+func (p *textinputPlugin) BackspaceSimple(){
 	if len(p.word) > 0 && p.selectionBase > 0 {
-		if modsIsWordModifier {
-			deleteUpTo := indexStartLeadingWord(p.word, p.selectionBase)
-			p.word = append(p.word[:deleteUpTo], p.word[p.selectionBase:]...)
-			p.selectionBase = deleteUpTo
-			p.selectionExtent = deleteUpTo
-			p.updateEditingState()
-		} else {
-			p.word = append(p.word[:p.selectionBase-1], p.word[p.selectionBase:]...)
-			if p.selectionBase > 0 {
-				p.selectionBase--
-			}
-			p.selectionExtent = p.selectionBase
-			p.updateEditingState()
-		}
+		p.word = append(p.word[:p.selectionBase-1], p.word[p.selectionBase:]...)
+		p.selectionBase--
+		p.selectionExtent = p.selectionBase
+		p.updateEditingState()
 	}
+}
 
+func (p *textinputPlugin) BackspaceWord(){
+	if len(p.word) > 0 && p.selectionBase > 0 {
+		deleteUpTo := indexStartLeadingWord(p.word, p.selectionBase)
+		p.word = append(p.word[:deleteUpTo], p.word[p.selectionBase:]...)
+		p.selectionBase = deleteUpTo
+		p.selectionExtent = deleteUpTo
+		p.updateEditingState()
+	}
+}
+
+func (p *textinputPlugin) BackspaceLine(){
+	p.word = p.word[:0]
+	p.selectionBase = 0
+	p.selectionExtent = 0
+	p.updateEditingState()
 }
 
 // RemoveSelectedText do nothing if no text is selected

--- a/textinput_model.go
+++ b/textinput_model.go
@@ -20,7 +20,7 @@ func (p *textinputPlugin) isSelected() bool {
 }
 
 func (p *textinputPlugin) addChar(char []rune) {
-	p.RemoveSelectedText()
+	p.removeSelectedText()
 	newWord := make([]rune, 0, len(char)+len(p.word))
 	newWord = append(newWord, p.word[:p.selectionBase]...)
 	newWord = append(newWord, char...)
@@ -115,7 +115,7 @@ func (p *textinputPlugin) extentSelectionRightReset() {
 	}
 }
 
-func (p *textinputPlugin) SelectAll() {
+func (p *textinputPlugin) selectAll() {
 	p.selectionBase = 0
 	p.selectionExtent = len(p.word)
 }
@@ -161,11 +161,11 @@ func (p *textinputPlugin) sliceLeftLine() {
 	p.selectionExtent = 0
 }
 
-// RemoveSelectedText do nothing if no text is selected
+// removeSelectedText do nothing if no text is selected
 // return true if the state has been updated
-func (p *textinputPlugin) RemoveSelectedText() bool {
+func (p *textinputPlugin) removeSelectedText() bool {
 	if p.isSelected() {
-		selectionIndexStart, selectionIndexEnd, _ := p.GetSelectedText()
+		selectionIndexStart, selectionIndexEnd, _ := p.getSelectedText()
 		p.word = append(p.word[:selectionIndexStart], p.word[selectionIndexEnd:]...)
 		p.selectionBase = selectionIndexStart
 		p.selectionExtent = selectionIndexStart
@@ -177,10 +177,10 @@ func (p *textinputPlugin) RemoveSelectedText() bool {
 
 }
 
-// GetSelectedText return
+// getSelectedText return
 // (left index of the selection, right index of the selection,
 // the content of the selection)
-func (p *textinputPlugin) GetSelectedText() (int, int, string) {
+func (p *textinputPlugin) getSelectedText() (int, int, string) {
 	selectionIndex := []int{p.selectionBase, p.selectionExtent}
 	sort.Ints(selectionIndex)
 	return selectionIndex[0],

--- a/textinput_model.go
+++ b/textinput_model.go
@@ -51,19 +51,19 @@ func (p *textinputPlugin) moveCursorEndSelect() {
 	p.selectionBase = len(p.word)
 }
 
-func (p *textinputPlugin) extentSelectionCharLeft() {
+func (p *textinputPlugin) extentSelectionLeftChar() {
 	if p.selectionExtent > 0 {
 		p.selectionExtent--
 	}
 }
 
-func (p *textinputPlugin) extentSelectionWordLeft() {
+func (p *textinputPlugin) extentSelectionLeftWord() {
 	p.selectionBase = indexStartLeadingWord(p.word, p.selectionBase)
 	p.selectionExtent = p.selectionBase
 
 }
 
-func (p *textinputPlugin) extentSelectionLineLeft() {
+func (p *textinputPlugin) extentSelectionLeftLine() {
 	if p.isSelected() {
 		p.selectionExtent = indexStartLeadingWord(p.word, p.selectionExtent)
 	} else {
@@ -72,7 +72,7 @@ func (p *textinputPlugin) extentSelectionLineLeft() {
 
 }
 
-func (p *textinputPlugin) extentSelectionResetLeft() {
+func (p *textinputPlugin) extentSelectionLeftReset() {
 	if !p.isSelected() {
 		if p.selectionBase > 0 {
 			p.selectionBase--
@@ -83,19 +83,19 @@ func (p *textinputPlugin) extentSelectionResetLeft() {
 	}
 }
 
-func (p *textinputPlugin) extentSelectionCharRight() {
+func (p *textinputPlugin) extentSelectionRightChar() {
 	if p.selectionExtent < len(p.word) {
 		p.selectionExtent++
 	}
 }
 
-func (p *textinputPlugin) extentSelectionWordRight() {
+func (p *textinputPlugin) extentSelectionRightWord() {
 	p.selectionBase = indexEndForwardWord(p.word, p.selectionBase)
 	p.selectionExtent = p.selectionBase
 
 }
 
-func (p *textinputPlugin) extentSelectionLineRight() {
+func (p *textinputPlugin) extentSelectionRightLine() {
 	if p.isSelected() {
 		p.selectionExtent = indexEndForwardWord(p.word, p.selectionExtent)
 	} else {
@@ -104,7 +104,7 @@ func (p *textinputPlugin) extentSelectionLineRight() {
 
 }
 
-func (p *textinputPlugin) extentSelectionResetRight() {
+func (p *textinputPlugin) extentSelectionRightReset() {
 	if !p.isSelected() {
 		if p.selectionBase < len(p.word) {
 			p.selectionBase++
@@ -120,23 +120,23 @@ func (p *textinputPlugin) SelectAll() {
 	p.selectionExtent = len(p.word)
 }
 
-func (p *textinputPlugin) deleteChar() {
+func (p *textinputPlugin) sliceRightChar() {
 	if p.selectionBase < len(p.word) {
 		p.word = append(p.word[:p.selectionBase], p.word[p.selectionBase+1:]...)
 
 	}
 }
 
-func (p *textinputPlugin) deleteWord() {
+func (p *textinputPlugin) sliceRightWord() {
 	UpTo := indexEndForwardWord(p.word, p.selectionBase)
 	p.word = append(p.word[:p.selectionBase], p.word[UpTo:]...)
 }
 
-func (p *textinputPlugin) deleteLine() {
+func (p *textinputPlugin) sliceRightLine() {
 	p.word = p.word[:p.selectionBase]
 }
 
-func (p *textinputPlugin) backspaceChar() {
+func (p *textinputPlugin) sliceLeftChar() {
 	if len(p.word) > 0 && p.selectionBase > 0 {
 		p.word = append(p.word[:p.selectionBase-1], p.word[p.selectionBase:]...)
 		p.selectionBase--
@@ -145,7 +145,7 @@ func (p *textinputPlugin) backspaceChar() {
 	}
 }
 
-func (p *textinputPlugin) backspaceWord() {
+func (p *textinputPlugin) sliceLeftWord() {
 	if len(p.word) > 0 && p.selectionBase > 0 {
 		deleteUpTo := indexStartLeadingWord(p.word, p.selectionBase)
 		p.word = append(p.word[:deleteUpTo], p.word[p.selectionBase:]...)
@@ -155,7 +155,7 @@ func (p *textinputPlugin) backspaceWord() {
 	}
 }
 
-func (p *textinputPlugin) backspaceLine() {
+func (p *textinputPlugin) sliceLeftLine() {
 	p.word = p.word[:0]
 	p.selectionBase = 0
 	p.selectionExtent = 0

--- a/textinput_model.go
+++ b/textinput_model.go
@@ -51,19 +51,19 @@ func (p *textinputPlugin) moveCursorEndSelect() {
 	p.selectionBase = len(p.word)
 }
 
-func (p *textinputPlugin) extentSelectionLeftChar() {
+func (p *textinputPlugin) extendSelectionLeftChar() {
 	if p.selectionExtent > 0 {
 		p.selectionExtent--
 	}
 }
 
-func (p *textinputPlugin) extentSelectionLeftWord() {
+func (p *textinputPlugin) extendSelectionLeftWord() {
 	p.selectionBase = indexStartLeadingWord(p.word, p.selectionBase)
 	p.selectionExtent = p.selectionBase
 
 }
 
-func (p *textinputPlugin) extentSelectionLeftLine() {
+func (p *textinputPlugin) extendSelectionLeftLine() {
 	if p.isSelected() {
 		p.selectionExtent = indexStartLeadingWord(p.word, p.selectionExtent)
 	} else {
@@ -72,7 +72,7 @@ func (p *textinputPlugin) extentSelectionLeftLine() {
 
 }
 
-func (p *textinputPlugin) extentSelectionLeftReset() {
+func (p *textinputPlugin) extendSelectionLeftReset() {
 	if !p.isSelected() {
 		if p.selectionBase > 0 {
 			p.selectionBase--
@@ -83,19 +83,19 @@ func (p *textinputPlugin) extentSelectionLeftReset() {
 	}
 }
 
-func (p *textinputPlugin) extentSelectionRightChar() {
+func (p *textinputPlugin) extendSelectionRightChar() {
 	if p.selectionExtent < len(p.word) {
 		p.selectionExtent++
 	}
 }
 
-func (p *textinputPlugin) extentSelectionRightWord() {
+func (p *textinputPlugin) extendSelectionRightWord() {
 	p.selectionBase = indexEndForwardWord(p.word, p.selectionBase)
 	p.selectionExtent = p.selectionBase
 
 }
 
-func (p *textinputPlugin) extentSelectionRightLine() {
+func (p *textinputPlugin) extendSelectionRightLine() {
 	if p.isSelected() {
 		p.selectionExtent = indexEndForwardWord(p.word, p.selectionExtent)
 	} else {
@@ -104,7 +104,7 @@ func (p *textinputPlugin) extentSelectionRightLine() {
 
 }
 
-func (p *textinputPlugin) extentSelectionRightReset() {
+func (p *textinputPlugin) extendSelectionRightReset() {
 	if !p.isSelected() {
 		if p.selectionBase < len(p.word) {
 			p.selectionBase++

--- a/textinput_model.go
+++ b/textinput_model.go
@@ -30,6 +30,7 @@ func (p *textinputPlugin) addChar(char []rune) {
 
 	p.selectionBase += len(char)
 	p.selectionExtent = p.selectionBase
+	p.updateEditingState()
 }
 
 func (p *textinputPlugin) MoveCursorHomeSimple() {

--- a/textinput_model.go
+++ b/textinput_model.go
@@ -30,40 +30,33 @@ func (p *textinputPlugin) addChar(char []rune) {
 
 	p.selectionBase += len(char)
 	p.selectionExtent = p.selectionBase
-	p.updateEditingState()
 }
 
 func (p *textinputPlugin) MoveCursorHomeSimple() {
 	p.selectionBase = 0
 	p.selectionExtent = p.selectionBase
-	p.updateEditingState()
 }
 
 func (p *textinputPlugin) MoveCursorHomeSelect() {
 	p.selectionBase = 0
-	p.updateEditingState()
 }
 
 func (p *textinputPlugin) MoveCursorEndSimple() {
 	p.selectionBase = len(p.word)
 	p.selectionExtent = p.selectionBase
-	p.updateEditingState()
 }
 
 func (p *textinputPlugin) MoveCursorEndSelect() {
 	p.selectionBase = len(p.word)
-	p.updateEditingState()
 }
 
 func (p *textinputPlugin) MoveCursorLeftSimple() {
 	p.selectionExtent--
-	p.updateEditingState()
 }
 
 func (p *textinputPlugin) MoveCursorLeftWord() {
 	p.selectionBase = indexStartLeadingWord(p.word, p.selectionBase)
 	p.selectionExtent = p.selectionBase
-	p.updateEditingState()
 
 }
 
@@ -73,7 +66,6 @@ func (p *textinputPlugin) MoveCursorLeftLine() {
 	} else {
 		p.selectionExtent = indexStartLeadingWord(p.word, p.selectionBase)
 	}
-	p.updateEditingState()
 
 }
 
@@ -86,18 +78,15 @@ func (p *textinputPlugin) MoveCursorLeftReset() {
 	} else {
 		p.selectionBase = p.selectionExtent
 	}
-	p.updateEditingState()
 }
 
 func (p *textinputPlugin) MoveCursorRightSimple() {
 	p.selectionExtent++
-	p.updateEditingState()
 }
 
 func (p *textinputPlugin) MoveCursorRightWord() {
 	p.selectionBase = indexEndForwardWord(p.word, p.selectionBase)
 	p.selectionExtent = p.selectionBase
-	p.updateEditingState()
 
 }
 
@@ -107,7 +96,6 @@ func (p *textinputPlugin) MoveCursorRightLine() {
 	} else {
 		p.selectionExtent = indexEndForwardWord(p.word, p.selectionBase)
 	}
-	p.updateEditingState()
 
 }
 
@@ -120,31 +108,27 @@ func (p *textinputPlugin) MoveCursorRightReset() {
 	} else {
 		p.selectionBase = p.selectionExtent
 	}
-	p.updateEditingState()
 }
 
 func (p *textinputPlugin) SelectAll() {
 	p.selectionBase = 0
 	p.selectionExtent = len(p.word)
-	p.updateEditingState()
 }
 
 func (p *textinputPlugin) DeleteSimple() {
 	if p.selectionBase < len(p.word) {
 		p.word = append(p.word[:p.selectionBase], p.word[p.selectionBase+1:]...)
-		p.updateEditingState()
+
 	}
 }
 
 func (p *textinputPlugin) DeleteWord() {
 	UpTo := indexEndForwardWord(p.word, p.selectionBase)
 	p.word = append(p.word[:p.selectionBase], p.word[UpTo:]...)
-	p.updateEditingState()
 }
 
 func (p *textinputPlugin) DeleteLine() {
 	p.word = p.word[:p.selectionBase]
-	p.updateEditingState()
 }
 
 
@@ -153,7 +137,7 @@ func (p *textinputPlugin) BackspaceSimple(){
 		p.word = append(p.word[:p.selectionBase-1], p.word[p.selectionBase:]...)
 		p.selectionBase--
 		p.selectionExtent = p.selectionBase
-		p.updateEditingState()
+
 	}
 }
 
@@ -163,7 +147,7 @@ func (p *textinputPlugin) BackspaceWord(){
 		p.word = append(p.word[:deleteUpTo], p.word[p.selectionBase:]...)
 		p.selectionBase = deleteUpTo
 		p.selectionExtent = deleteUpTo
-		p.updateEditingState()
+
 	}
 }
 
@@ -171,7 +155,6 @@ func (p *textinputPlugin) BackspaceLine(){
 	p.word = p.word[:0]
 	p.selectionBase = 0
 	p.selectionExtent = 0
-	p.updateEditingState()
 }
 
 // RemoveSelectedText do nothing if no text is selected
@@ -183,7 +166,7 @@ func (p *textinputPlugin) RemoveSelectedText() bool {
 		p.selectionBase = selectionIndexStart
 		p.selectionExtent = selectionIndexStart
 		p.selectionExtent = p.selectionBase
-		p.updateEditingState()
+
 		return true
 	}
 	return false

--- a/textinput_model.go
+++ b/textinput_model.go
@@ -33,35 +33,37 @@ func (p *textinputPlugin) addChar(char []rune) {
 	p.updateEditingState()
 }
 
-func (p *textinputPlugin) MoveCursorHomeSimple() {
+func (p *textinputPlugin) moveCursorHomeSimple() {
 	p.selectionBase = 0
 	p.selectionExtent = p.selectionBase
 }
 
-func (p *textinputPlugin) MoveCursorHomeSelect() {
+func (p *textinputPlugin) moveCursorHomeSelect() {
 	p.selectionBase = 0
 }
 
-func (p *textinputPlugin) MoveCursorEndSimple() {
+func (p *textinputPlugin) moveCursorEndSimple() {
 	p.selectionBase = len(p.word)
 	p.selectionExtent = p.selectionBase
 }
 
-func (p *textinputPlugin) MoveCursorEndSelect() {
+func (p *textinputPlugin) moveCursorEndSelect() {
 	p.selectionBase = len(p.word)
 }
 
-func (p *textinputPlugin) MoveCursorLeftSimple() {
-	p.selectionExtent--
+func (p *textinputPlugin) extentSelectionCharLeft() {
+	if p.selectionExtent > 0 {
+		p.selectionExtent--
+	}
 }
 
-func (p *textinputPlugin) MoveCursorLeftWord() {
+func (p *textinputPlugin) extentSelectionWordLeft() {
 	p.selectionBase = indexStartLeadingWord(p.word, p.selectionBase)
 	p.selectionExtent = p.selectionBase
 
 }
 
-func (p *textinputPlugin) MoveCursorLeftLine() {
+func (p *textinputPlugin) extentSelectionLineLeft() {
 	if p.isSelected() {
 		p.selectionExtent = indexStartLeadingWord(p.word, p.selectionExtent)
 	} else {
@@ -70,7 +72,7 @@ func (p *textinputPlugin) MoveCursorLeftLine() {
 
 }
 
-func (p *textinputPlugin) MoveCursorLeftReset() {
+func (p *textinputPlugin) extentSelectionResetLeft() {
 	if !p.isSelected() {
 		if p.selectionBase > 0 {
 			p.selectionBase--
@@ -81,17 +83,19 @@ func (p *textinputPlugin) MoveCursorLeftReset() {
 	}
 }
 
-func (p *textinputPlugin) MoveCursorRightSimple() {
-	p.selectionExtent++
+func (p *textinputPlugin) extentSelectionCharRight() {
+	if p.selectionExtent < len(p.word) {
+		p.selectionExtent++
+	}
 }
 
-func (p *textinputPlugin) MoveCursorRightWord() {
+func (p *textinputPlugin) extentSelectionWordRight() {
 	p.selectionBase = indexEndForwardWord(p.word, p.selectionBase)
 	p.selectionExtent = p.selectionBase
 
 }
 
-func (p *textinputPlugin) MoveCursorRightLine() {
+func (p *textinputPlugin) extentSelectionLineRight() {
 	if p.isSelected() {
 		p.selectionExtent = indexEndForwardWord(p.word, p.selectionExtent)
 	} else {
@@ -100,7 +104,7 @@ func (p *textinputPlugin) MoveCursorRightLine() {
 
 }
 
-func (p *textinputPlugin) MoveCursorRightReset() {
+func (p *textinputPlugin) extentSelectionResetRight() {
 	if !p.isSelected() {
 		if p.selectionBase < len(p.word) {
 			p.selectionBase++
@@ -116,24 +120,23 @@ func (p *textinputPlugin) SelectAll() {
 	p.selectionExtent = len(p.word)
 }
 
-func (p *textinputPlugin) DeleteSimple() {
+func (p *textinputPlugin) deleteChar() {
 	if p.selectionBase < len(p.word) {
 		p.word = append(p.word[:p.selectionBase], p.word[p.selectionBase+1:]...)
 
 	}
 }
 
-func (p *textinputPlugin) DeleteWord() {
+func (p *textinputPlugin) deleteWord() {
 	UpTo := indexEndForwardWord(p.word, p.selectionBase)
 	p.word = append(p.word[:p.selectionBase], p.word[UpTo:]...)
 }
 
-func (p *textinputPlugin) DeleteLine() {
+func (p *textinputPlugin) deleteLine() {
 	p.word = p.word[:p.selectionBase]
 }
 
-
-func (p *textinputPlugin) BackspaceSimple(){
+func (p *textinputPlugin) backspaceChar() {
 	if len(p.word) > 0 && p.selectionBase > 0 {
 		p.word = append(p.word[:p.selectionBase-1], p.word[p.selectionBase:]...)
 		p.selectionBase--
@@ -142,7 +145,7 @@ func (p *textinputPlugin) BackspaceSimple(){
 	}
 }
 
-func (p *textinputPlugin) BackspaceWord(){
+func (p *textinputPlugin) backspaceWord() {
 	if len(p.word) > 0 && p.selectionBase > 0 {
 		deleteUpTo := indexStartLeadingWord(p.word, p.selectionBase)
 		p.word = append(p.word[:deleteUpTo], p.word[p.selectionBase:]...)
@@ -152,7 +155,7 @@ func (p *textinputPlugin) BackspaceWord(){
 	}
 }
 
-func (p *textinputPlugin) BackspaceLine(){
+func (p *textinputPlugin) backspaceLine() {
 	p.word = p.word[:0]
 	p.selectionBase = 0
 	p.selectionExtent = 0

--- a/textinput_model.go
+++ b/textinput_model.go
@@ -33,7 +33,7 @@ func (p *textinputPlugin) addChar(char []rune) {
 	p.updateEditingState()
 }
 
-func (p *textinputPlugin) moveCursorHomeSimple() {
+func (p *textinputPlugin) moveCursorHomeNoSelect() {
 	p.selectionBase = 0
 	p.selectionExtent = p.selectionBase
 }
@@ -42,7 +42,7 @@ func (p *textinputPlugin) moveCursorHomeSelect() {
 	p.selectionBase = 0
 }
 
-func (p *textinputPlugin) moveCursorEndSimple() {
+func (p *textinputPlugin) moveCursorEndNoSelect() {
 	p.selectionBase = len(p.word)
 	p.selectionExtent = p.selectionBase
 }

--- a/textinput_windows.go
+++ b/textinput_windows.go
@@ -64,7 +64,7 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 		return
 	}
 
-	if mods.isModifier() {
+	if mods.isWordTravelShift() {
 		p.sliceLeftLine()
 	} else if mods.isWordTravel() {
 		p.sliceLeftWord()

--- a/textinput_windows.go
+++ b/textinput_windows.go
@@ -59,7 +59,7 @@ func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 }
 
 func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
-	if p.RemoveSelectedText() {
+	if p.removeSelectedText() {
 		p.updateEditingState()
 		return
 	}
@@ -74,7 +74,7 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 }
 
 func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
-	if p.RemoveSelectedText() {
+	if p.removeSelectedText() {
 		p.updateEditingState()
 		return
 	}

--- a/textinput_windows.go
+++ b/textinput_windows.go
@@ -36,25 +36,25 @@ func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 
 func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.MoveCursorLeftLine()
+		p.extentSelectionLineLeft()
 	} else if mods.isWordTravel() {
-		p.MoveCursorLeftWord()
+		p.extentSelectionWordLeft()
 	} else if mods.isShift() {
-		p.MoveCursorLeftSimple()
+		p.extentSelectionCharLeft()
 	} else {
-		p.MoveCursorLeftReset()
+		p.extentSelectionResetLeft()
 	}
 }
 
 func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.MoveCursorRightLine()
+		p.extentSelectionLineRight()
 	} else if mods.isWordTravel() {
-		p.MoveCursorRightWord()
+		p.extentSelectionWordRight()
 	} else if mods.isShift() {
-		p.MoveCursorRightSimple()
+		p.extentSelectionCharRight()
 	} else {
-		p.MoveCursorRightReset()
+		p.extentSelectionResetRight()
 	}
 }
 
@@ -69,7 +69,7 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 	} else if mods.isWordTravel() {
 		p.BackspaceWord()
 	} else {
-		p.BackspaceSimple()
+		p.backspaceChar()
 	}
 }
 
@@ -84,6 +84,6 @@ func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
 	} else if mods.isWordTravel() {
 		p.DeleteWord()
 	} else {
-		p.DeleteSimple()
+		p.deleteChar()
 	}
 }

--- a/textinput_windows.go
+++ b/textinput_windows.go
@@ -22,7 +22,7 @@ func (p *textinputPlugin) MoveCursorHome(mods keyboardShortcutsGLFW) {
 	if mods.isShift() {
 		p.moveCursorHomeSelect()
 	} else {
-		p.moveCursorHomeSimple()
+		p.moveCursorHomeNoSelect()
 	}
 }
 
@@ -30,7 +30,7 @@ func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 	if mods.isShift() {
 		p.moveCursorEndSelect()
 	} else {
-		p.moveCursorEndSimple()
+		p.moveCursorEndNoSelect()
 	}
 }
 

--- a/textinput_windows.go
+++ b/textinput_windows.go
@@ -20,17 +20,17 @@ func (p *keyboardShortcutsGLFW) isWordTravelShift() bool {
 
 func (p *textinputPlugin) MoveCursorHome(mods keyboardShortcutsGLFW) {
 	if mods.isShift() {
-		p.MoveCursorHomeSelect()
+		p.moveCursorHomeSelect()
 	} else {
-		p.MoveCursorHomeSimple()
+		p.moveCursorHomeSimple()
 	}
 }
 
 func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 	if mods.isShift() {
-		p.MoveCursorEndSelect()
+		p.moveCursorEndSelect()
 	} else {
-		p.MoveCursorEndSimple()
+		p.moveCursorEndSimple()
 	}
 }
 
@@ -65,9 +65,9 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 	}
 
 	if mods.isModifier() {
-		p.BackspaceLine()
+		p.backspaceLine()
 	} else if mods.isWordTravel() {
-		p.BackspaceWord()
+		p.backspaceWord()
 	} else {
 		p.backspaceChar()
 	}
@@ -80,9 +80,9 @@ func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
 	}
 
 	if mods.isWordTravelShift() {
-		p.DeleteLine()
+		p.deleteLine()
 	} else if mods.isWordTravel() {
-		p.DeleteWord()
+		p.deleteWord()
 	} else {
 		p.deleteChar()
 	}

--- a/textinput_windows.go
+++ b/textinput_windows.go
@@ -36,25 +36,25 @@ func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 
 func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.extentSelectionLeftLine()
+		p.extendSelectionLeftLine()
 	} else if mods.isWordTravel() {
-		p.extentSelectionLeftWord()
+		p.extendSelectionLeftWord()
 	} else if mods.isShift() {
-		p.extentSelectionLeftChar()
+		p.extendSelectionLeftChar()
 	} else {
-		p.extentSelectionLeftReset()
+		p.extendSelectionLeftReset()
 	}
 }
 
 func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.extentSelectionRightLine()
+		p.extendSelectionRightLine()
 	} else if mods.isWordTravel() {
-		p.extentSelectionRightWord()
+		p.extendSelectionRightWord()
 	} else if mods.isShift() {
-		p.extentSelectionRightChar()
+		p.extendSelectionRightChar()
 	} else {
-		p.extentSelectionRightReset()
+		p.extendSelectionRightReset()
 	}
 }
 

--- a/textinput_windows.go
+++ b/textinput_windows.go
@@ -1,0 +1,87 @@
+package flutter
+
+func (p *keyboardShortcutsGLFW) isModifier() bool {
+	return p.mod & glfw.ModControl != 0
+}
+
+func (p *keyboardShortcutsGLFW) isShift() bool {
+	return p.mod & glfw.ModShift != 0
+}
+
+func (p *keyboardShortcutsGLFW) isWordTravel() bool {
+	return p.mod & glfw.ModControl != 0
+}
+
+func (p *keyboardShortcutsGLFW) isWordTravelShift() bool {
+	return p.mod & glfw.ModControl != 0 && p.mod & glfw.ModShift != 0
+}
+
+func (p *textinputPlugin) MoveCursorHome(mods keyboardShortcutsGLFW) {
+	if mods.isShift() {
+		p.MoveCursorHomeSelect()
+	} else {
+		p.MoveCursorHomeSimple()
+	}
+}
+
+func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
+	if mods.isShift() {
+		p.MoveCursorEndSelect()
+	} else {
+		p.MoveCursorEndSimple()
+	}
+}
+
+func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
+	if mods.isWordTravelShift() {
+		p.MoveCursorLeftLine()
+	} else if mods.isWordTravel() {
+		p.MoveCursorLeftWord()		
+	} else if mods.isShift() {
+		p.MoveCursorLeftSimple()
+	} else {
+		p.MoveCursorLeftReset()
+	}
+}
+
+func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
+	if mods.isWordTravelShift() {
+		p.MoveCursorRightLine()
+	} else if mods.isWordTravel() {
+		p.MoveCursorRightWord()		
+	} else if mods.isShift() {
+		p.MoveCursorRightSimple()
+	} else {
+		p.MoveCursorRightReset()
+	}
+}
+
+func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
+	if p.RemoveSelectedText() {
+		p.updateEditingState()
+		return
+	}
+
+	if mods.isModifier() {
+		p.BackspaceLine()
+	} else if mods.isWordTravel() {
+		p.BackspaceWord()
+	} else {
+		p.BackspaceSimple()
+	}
+}
+
+func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
+	if p.RemoveSelectedText() {
+		p.updateEditingState()
+		return
+	}
+
+	if mods.isWordTravelShift() {
+		p.DeleteLine()
+	} else if mods.isWordTravel() {
+		p.DeleteWord()
+	} else {
+		p.DeleteSimple()
+	}
+}

--- a/textinput_windows.go
+++ b/textinput_windows.go
@@ -1,19 +1,21 @@
 package flutter
 
+import "github.com/go-gl/glfw/v3.2/glfw"
+
 func (p *keyboardShortcutsGLFW) isModifier() bool {
-	return p.mod & glfw.ModControl != 0
+	return p.mod&glfw.ModControl != 0
 }
 
 func (p *keyboardShortcutsGLFW) isShift() bool {
-	return p.mod & glfw.ModShift != 0
+	return p.mod&glfw.ModShift != 0
 }
 
 func (p *keyboardShortcutsGLFW) isWordTravel() bool {
-	return p.mod & glfw.ModControl != 0
+	return p.mod&glfw.ModControl != 0
 }
 
 func (p *keyboardShortcutsGLFW) isWordTravelShift() bool {
-	return p.mod & glfw.ModControl != 0 && p.mod & glfw.ModShift != 0
+	return p.mod&glfw.ModControl != 0 && p.mod&glfw.ModShift != 0
 }
 
 func (p *textinputPlugin) MoveCursorHome(mods keyboardShortcutsGLFW) {
@@ -36,7 +38,7 @@ func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
 		p.MoveCursorLeftLine()
 	} else if mods.isWordTravel() {
-		p.MoveCursorLeftWord()		
+		p.MoveCursorLeftWord()
 	} else if mods.isShift() {
 		p.MoveCursorLeftSimple()
 	} else {
@@ -48,7 +50,7 @@ func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
 		p.MoveCursorRightLine()
 	} else if mods.isWordTravel() {
-		p.MoveCursorRightWord()		
+		p.MoveCursorRightWord()
 	} else if mods.isShift() {
 		p.MoveCursorRightSimple()
 	} else {

--- a/textinput_windows.go
+++ b/textinput_windows.go
@@ -36,25 +36,25 @@ func (p *textinputPlugin) MoveCursorEnd(mods keyboardShortcutsGLFW) {
 
 func (p *textinputPlugin) MoveCursorLeft(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.extentSelectionLineLeft()
+		p.extentSelectionLeftLine()
 	} else if mods.isWordTravel() {
-		p.extentSelectionWordLeft()
+		p.extentSelectionLeftWord()
 	} else if mods.isShift() {
-		p.extentSelectionCharLeft()
+		p.extentSelectionLeftChar()
 	} else {
-		p.extentSelectionResetLeft()
+		p.extentSelectionLeftReset()
 	}
 }
 
 func (p *textinputPlugin) MoveCursorRight(mods keyboardShortcutsGLFW) {
 	if mods.isWordTravelShift() {
-		p.extentSelectionLineRight()
+		p.extentSelectionRightLine()
 	} else if mods.isWordTravel() {
-		p.extentSelectionWordRight()
+		p.extentSelectionRightWord()
 	} else if mods.isShift() {
-		p.extentSelectionCharRight()
+		p.extentSelectionRightChar()
 	} else {
-		p.extentSelectionResetRight()
+		p.extentSelectionRightReset()
 	}
 }
 
@@ -65,11 +65,11 @@ func (p *textinputPlugin) Backspace(mods keyboardShortcutsGLFW) {
 	}
 
 	if mods.isModifier() {
-		p.backspaceLine()
+		p.sliceLeftLine()
 	} else if mods.isWordTravel() {
-		p.backspaceWord()
+		p.sliceLeftWord()
 	} else {
-		p.backspaceChar()
+		p.sliceLeftChar()
 	}
 }
 
@@ -80,10 +80,10 @@ func (p *textinputPlugin) Delete(mods keyboardShortcutsGLFW) {
 	}
 
 	if mods.isWordTravelShift() {
-		p.deleteLine()
+		p.sliceRightLine()
 	} else if mods.isWordTravel() {
-		p.deleteWord()
+		p.sliceRightWord()
 	} else {
-		p.deleteChar()
+		p.sliceRightChar()
 	}
 }


### PR DESCRIPTION
Under Linux/ Windows:  
 * `Delete + Ctrl + Shift` : delete entire line in front of the cursor (right)  
 * `Delete + Ctrl` : delete word in front of the cursor (right)  

Under MacOS :  
( Delete doesn't exist on MacOs keyboard, replaced by `Fn + Backspace`)  
 * `Fn + Alt + Shift + Backspace` : delete entire line in front of the cursor (right)  
 * `Fn + Alt + Backspace`: delete word in front of the cursor (right)  