### PR TITLE
FIX Crash when replying with an error from a plugin

### DIFF
--- a/plugin/method-channel.go
+++ b/plugin/method-channel.go
@@ -167,11 +167,11 @@ func (m *MethodChannel) handleMethodCall(handler MethodHandler, methodCall Metho
 			fmt.Printf("go-flutter: failed to encode error envelope for method '%s' on channel '%s', error: %v\n", methodCall.Method, m.channelName, err)
 		}
 		responseSender.Send(binaryReply)
-	} else {
-		binaryReply, err := m.methodCodec.EncodeSuccessEnvelope(reply)
-		if err != nil {
-			fmt.Printf("go-flutter: failed to encode success envelope for method '%s' on channel '%s', error: %v\n", methodCall.Method, m.channelName, err)
-		}
-		responseSender.Send(binaryReply)
-	}	
+		return
+	}
+	binaryReply, err := m.methodCodec.EncodeSuccessEnvelope(reply)
+	if err != nil {
+		fmt.Printf("go-flutter: failed to encode success envelope for method '%s' on channel '%s', error: %v\n", methodCall.Method, m.channelName, err)
+	}
+	responseSender.Send(binaryReply)
 }

--- a/plugin/method-channel.go
+++ b/plugin/method-channel.go
@@ -167,11 +167,11 @@ func (m *MethodChannel) handleMethodCall(handler MethodHandler, methodCall Metho
 			fmt.Printf("go-flutter: failed to encode error envelope for method '%s' on channel '%s', error: %v\n", methodCall.Method, m.channelName, err)
 		}
 		responseSender.Send(binaryReply)
-	}
-
-	binaryReply, err := m.methodCodec.EncodeSuccessEnvelope(reply)
-	if err != nil {
-		fmt.Printf("go-flutter: failed to encode success envelope for method '%s' on channel '%s', error: %v\n", methodCall.Method, m.channelName, err)
-	}
-	responseSender.Send(binaryReply)
+	} else {
+		binaryReply, err := m.methodCodec.EncodeSuccessEnvelope(reply)
+		if err != nil {
+			fmt.Printf("go-flutter: failed to encode success envelope for method '%s' on channel '%s', error: %v\n", methodCall.Method, m.channelName, err)
+		}
+		responseSender.Send(binaryReply)
+	}	
 }


### PR DESCRIPTION
When sending an error from a plugin, 2 responses where being sent to the Dart side, causing a crash. 