### PR TITLE
feature: PathPrefix

### DIFF
--- a/plugin/basic-message-channel.go
+++ b/plugin/basic-message-channel.go
@@ -42,7 +42,7 @@ type BasicMessageChannel struct {
 // NewBasicMessageChannel creates a BasicMessageChannel.
 //
 // Call Handle or HandleFunc on the returned BasicMessageChannel to provide the
-// channel with a handler for incomming messages.
+// channel with a handler for incoming messages.
 func NewBasicMessageChannel(messenger BinaryMessenger, channelName string, codec MessageCodec) *BasicMessageChannel {
 	b := &BasicMessageChannel{
 		messenger:   messenger,
@@ -68,7 +68,7 @@ func (b *BasicMessageChannel) Send(message interface{}) (reply interface{}, err 
 	}
 	reply, err = b.codec.DecodeMessage(encodedReply)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode incomming reply")
+		return nil, errors.Wrap(err, "failed to decode incoming reply")
 	}
 	return reply, nil
 }
@@ -104,7 +104,7 @@ func (b *BasicMessageChannel) handleChannelMessage(binaryMessage []byte, r Respo
 	}
 	message, err := b.codec.DecodeMessage(binaryMessage)
 	if err != nil {
-		return errors.Wrap(err, "failed to decode incomming message")
+		return errors.Wrap(err, "failed to decode incoming message")
 	}
 	reply, err := b.handler.HandleMessage(message)
 	if err != nil {

--- a/plugin/event-channel.go
+++ b/plugin/event-channel.go
@@ -47,7 +47,7 @@ func (e *EventChannel) Handle(handler StreamHandler) {
 func (e *EventChannel) handleChannelMessage(binaryMessage []byte, responseSender ResponseSender) (err error) {
 	methodCall, err := e.methodCodec.DecodeMethodCall(binaryMessage)
 	if err != nil {
-		return errors.Wrap(err, "failed to decode incomming message")
+		return errors.Wrap(err, "failed to decode incoming message")
 	}
 
 	if e.handler == nil {

--- a/plugin/method-channel.go
+++ b/plugin/method-channel.go
@@ -2,6 +2,8 @@ package plugin
 
 import (
 	"fmt"
+	"os"
+	"regexp"
 	"runtime/debug"
 	"sync"
 
@@ -18,12 +20,27 @@ type MethodChannel struct {
 	methodCodec MethodCodec
 
 	methods     map[string]methodHandlerRegistration
+	prefixRoute []*route
 	methodsLock sync.RWMutex
+}
+
+// PrefixMethodChannel provides a way of defining MethodHandler based on a
+// regex instead of a hard defined string.
+type PrefixMethodChannel struct {
+	methodChannel *MethodChannel
+
+	// the route regex used by the MethodHandler
+	route *route
 }
 
 type methodHandlerRegistration struct {
 	handler MethodHandler
 	sync    bool
+}
+
+type route struct {
+	name        string
+	routeRegexp *regexp.Regexp
 }
 
 // NewMethodChannel creates a new method channel
@@ -68,6 +85,39 @@ func (m *MethodChannel) InvokeMethod(name string, arguments interface{}) (result
 	return result, nil
 }
 
+func (m *MethodChannel) addRouteSync(r *route, handler MethodHandler) {
+	m.pushNewRoute(r, handler, true)
+}
+func (m *MethodChannel) addRoute(r *route, handler MethodHandler) {
+	m.pushNewRoute(r, handler, false)
+}
+
+func (m *MethodChannel) pushNewRoute(r *route, handler MethodHandler, sync bool) {
+	m.methodsLock.Lock()
+	if handler == nil {
+		// delete from map
+		delete(m.methods, r.name)
+		// delete from slice
+		i := 0
+		for _, x := range m.prefixRoute {
+			if x.name != r.name {
+				m.prefixRoute[i] = x
+				i++
+			}
+		}
+		m.prefixRoute = m.prefixRoute[:i]
+	} else {
+		if r.routeRegexp != nil {
+			m.prefixRoute = append(m.prefixRoute, r)
+		}
+		m.methods[r.name] = methodHandlerRegistration{
+			handler: handler,
+			sync:    sync,
+		}
+	}
+	m.methodsLock.Unlock()
+}
+
 // Handle registers a method handler for method calls with given name.
 //
 // Consecutive calls override any existing handler registration for (the name
@@ -77,18 +127,16 @@ func (m *MethodChannel) InvokeMethod(name string, arguments interface{}) (result
 // When no handler is registered for a method, it will be handled silently by
 // sending a nil reply which triggers the dart MissingPluginException exception.
 func (m *MethodChannel) Handle(methodName string, handler MethodHandler) {
-	m.methodsLock.Lock()
-	if handler == nil {
-		delete(m.methods, methodName)
-	} else {
-		m.methods[methodName] = methodHandlerRegistration{
-			handler: handler,
-		}
-	}
-	m.methodsLock.Unlock()
+	route := &route{
+		name:        methodName,
+		routeRegexp: nil}
+	m.addRoute(route, handler)
 }
 
-// HandleFunc is a shorthand for m.Handle(MethodHandlerFunc(f))
+// HandleFunc is a shorthand for m.Handle("name", MethodHandlerFunc(f))
+//
+// The argument of the function f is an interface corresponding to the
+// MethodCall.Arguments values
 func (m *MethodChannel) HandleFunc(methodName string, f func(arguments interface{}) (reply interface{}, err error)) {
 	if f == nil {
 		m.Handle(methodName, nil)
@@ -101,19 +149,16 @@ func (m *MethodChannel) HandleFunc(methodName string, f func(arguments interface
 // HandleSync is like Handle, but messages for given method are handled
 // synchronously.
 func (m *MethodChannel) HandleSync(methodName string, handler MethodHandler) {
-	m.methodsLock.Lock()
-	if handler == nil {
-		delete(m.methods, methodName)
-	} else {
-		m.methods[methodName] = methodHandlerRegistration{
-			handler: handler,
-			sync:    true,
-		}
-	}
-	m.methodsLock.Unlock()
+	route := &route{
+		name:        methodName,
+		routeRegexp: nil}
+	m.addRouteSync(route, handler)
 }
 
-// HandleFuncSync is a shorthand for m.HandleSync(MethodHandlerFunc(f))
+// HandleFuncSync is a shorthand for m.HandleSync("name", MethodHandlerFunc(f))
+//
+// The argument of the function f is an interface corresponding to the
+// MethodCall.Arguments values
 func (m *MethodChannel) HandleFuncSync(methodName string, f func(arguments interface{}) (reply interface{}, err error)) {
 	if f == nil {
 		m.HandleSync(methodName, nil)
@@ -128,50 +173,147 @@ func (m *MethodChannel) HandleFuncSync(methodName string, f func(arguments inter
 func (m *MethodChannel) handleChannelMessage(binaryMessage []byte, responseSender ResponseSender) (err error) {
 	methodCall, err := m.methodCodec.DecodeMethodCall(binaryMessage)
 	if err != nil {
-		return errors.Wrap(err, "failed to decode incomming message")
+		return errors.Wrap(err, "failed to decode incoming message")
 	}
 
 	m.methodsLock.RLock()
 	registration, registrationExists := m.methods[methodCall.Method]
 	m.methodsLock.RUnlock()
 	if !registrationExists {
-		fmt.Printf("go-flutter: no method handler registered for method '%s' on channel '%s'\n", methodCall.Method, m.channelName)
-		responseSender.Send(nil)
+
+		// finding a route that matches
+		var registration methodHandlerRegistration
+		m.methodsLock.RLock()
+		for _, re := range m.prefixRoute {
+			if re.routeRegexp.MatchString(methodCall.Method) {
+				registration = m.methods[re.name]
+				break
+			}
+		}
+		m.methodsLock.RUnlock()
+
+		if registration == (methodHandlerRegistration{}) {
+			fmt.Printf("go-flutter: no method handler registered for method '%s' on channel '%s'\n", methodCall.Method, m.channelName)
+			responseSender.Send(nil)
+			return nil
+		}
+
+		if registration.sync {
+			m.handleMethodCall(registration.handler, methodCall.Method, methodCall, responseSender)
+		} else {
+			go m.handleMethodCall(registration.handler, methodCall.Method, methodCall, responseSender)
+		}
 		return nil
 	}
 
 	if registration.sync {
-		m.handleMethodCall(registration.handler, methodCall, responseSender)
+		m.handleMethodCall(registration.handler, methodCall.Method, methodCall.Arguments, responseSender)
 	} else {
-		go m.handleMethodCall(registration.handler, methodCall, responseSender)
+		go m.handleMethodCall(registration.handler, methodCall.Method, methodCall.Arguments, responseSender)
 	}
 
 	return nil
 }
 
 // handleMethodCall handles the methodcall and sends a response.
-func (m *MethodChannel) handleMethodCall(handler MethodHandler, methodCall MethodCall, responseSender ResponseSender) {
+func (m *MethodChannel) handleMethodCall(handler MethodHandler, methodName string, methodArgs interface{}, responseSender ResponseSender) {
 	defer func() {
 		p := recover()
 		if p != nil {
-			fmt.Printf("go-flutter: recovered from panic while handling call for method '%s' on channel '%s': %v\n", methodCall.Method, m.channelName, p)
+			fmt.Printf("go-flutter: recovered from panic while handling call for method '%s' on channel '%s': %v\n", methodName, m.channelName, p)
 			debug.PrintStack()
 		}
 	}()
 
-	reply, err := handler.HandleMethod(methodCall.Arguments)
+	reply, err := handler.HandleMethod(methodArgs)
 	if err != nil {
-		fmt.Printf("go-flutter: handler for method '%s' on channel '%s' returned an error: %v\n", methodCall.Method, m.channelName, err)
+		fmt.Printf("go-flutter: handler for method '%s' on channel '%s' returned an error: %v\n", methodName, m.channelName, err)
 		binaryReply, err := m.methodCodec.EncodeErrorEnvelope("error", err.Error(), nil)
 		if err != nil {
-			fmt.Printf("go-flutter: failed to encode error envelope for method '%s' on channel '%s', error: %v\n", methodCall.Method, m.channelName, err)
+			fmt.Printf("go-flutter: failed to encode error envelope for method '%s' on channel '%s', error: %v\n", methodName, m.channelName, err)
 		}
 		responseSender.Send(binaryReply)
 		return
 	}
 	binaryReply, err := m.methodCodec.EncodeSuccessEnvelope(reply)
 	if err != nil {
-		fmt.Printf("go-flutter: failed to encode success envelope for method '%s' on channel '%s', error: %v\n", methodCall.Method, m.channelName, err)
+		fmt.Printf("go-flutter: failed to encode success envelope for method '%s' on channel '%s', error: %v\n", methodName, m.channelName, err)
 	}
 	responseSender.Send(binaryReply)
+}
+
+// PathPrefix registers a new route with a regex for the methodName.
+// PrefixMethodChannel expose a similar interface as MethodChannel.
+//
+// Instead of having a hard defined methodName string. The methodName is
+// matched to the tpl regex, if the match succeed,
+// PrefixMethodChannel.MethodHandler is used.
+//
+// If you use multiples PathPrefix in your plugin, the selection of the
+// MethodHandler follows the same as the order as the HandleFunc definition.
+func (m *MethodChannel) PathPrefix(tpl string) *PrefixMethodChannel {
+	regex, err := regexp.Compile(tpl)
+	if err != nil {
+		fmt.Printf("go-flutter: couldn't compile the PathPrefix regex: '%s', error: %v\n", tpl, err)
+		os.Exit(1)
+	}
+
+	route := &route{
+		name:        tpl,
+		routeRegexp: regex}
+
+	pmc := &PrefixMethodChannel{
+		route: route,
+	}
+	pmc.methodChannel = m
+
+	return pmc
+}
+
+// Handle registers a method handler for method calls with a name that matches
+// the routeRegexp.
+//
+// The MethodHandler defined on PrefixMethodChannel are only called if no
+// MethodChannel MethodHandler are found.
+// PrefixMethodChannel has a lower priority than MethodChannel.
+//
+// Consecutive calls override any existing handler registration for (the name
+// of) this method. When given nil as handler, the previously registered
+// handler for a method is unregistrered.
+//
+// When no handler is registered for a method, it will be handled silently by
+// sending a nil reply which triggers the dart MissingPluginException exception.
+func (pcm *PrefixMethodChannel) Handle(handler MethodHandler) {
+	pcm.methodChannel.addRoute(pcm.route, handler)
+}
+
+// HandleFunc is a shorthand for m.Handle(MethodHandlerFunc(f))
+//
+// The argument of the function f is a MethodCall struct
+func (pcm *PrefixMethodChannel) HandleFunc(f func(methodCall interface{}) (reply interface{}, err error)) {
+	if f == nil {
+		pcm.Handle(nil)
+		return
+	}
+
+	pcm.Handle(MethodHandlerFunc(f))
+}
+
+// HandleSync is like Handle, but messages for given method are handled
+// synchronously.
+func (pcm *PrefixMethodChannel) HandleSync(handler MethodHandler) {
+	pcm.methodChannel.addRouteSync(pcm.route, handler)
+
+}
+
+// HandleFuncSync is a shorthand for m.HandleSync(MethodHandlerFunc(f))
+//
+// The argument of the function f is a MethodCall struct
+func (pcm *PrefixMethodChannel) HandleFuncSync(f func(methodCall interface{}) (reply interface{}, err error)) {
+	if f == nil {
+		pcm.HandleSync(nil)
+		return
+	}
+
+	pcm.HandleSync(MethodHandlerFunc(f))
 }


### PR DESCRIPTION
fixes #196 
Inspired by [gorilla/mux](https://github.com/gorilla/mux) `PathPrefix`.
This PR adds the functionality to set MethodHandler for unknown Method name.

Example:
```go
channel.PathPrefix("test/").HandleFunc(pathPrefixTest)

func pathPrefixTest(methodCall interface{}) (reply interface{}, err error) {
	method := methodCall.(plugin.MethodCall) // access to MethodCall (instead of only MethodCall.Arguments)
	return method.Method, nil
}
```

Testing code:  https://github.com/go-flutter-desktop/examples/pull/12