### PR TITLE
Feature/fallback method handler

### DIFF
--- a/plugin/basic-message-channel.go
+++ b/plugin/basic-message-channel.go
@@ -42,7 +42,7 @@ type BasicMessageChannel struct {
 // NewBasicMessageChannel creates a BasicMessageChannel.
 //
 // Call Handle or HandleFunc on the returned BasicMessageChannel to provide the
-// channel with a handler for incomming messages.
+// channel with a handler for incoming messages.
 func NewBasicMessageChannel(messenger BinaryMessenger, channelName string, codec MessageCodec) *BasicMessageChannel {
 	b := &BasicMessageChannel{
 		messenger:   messenger,
@@ -68,7 +68,7 @@ func (b *BasicMessageChannel) Send(message interface{}) (reply interface{}, err 
 	}
 	reply, err = b.codec.DecodeMessage(encodedReply)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to decode incomming reply")
+		return nil, errors.Wrap(err, "failed to decode incoming reply")
 	}
 	return reply, nil
 }
@@ -104,7 +104,7 @@ func (b *BasicMessageChannel) handleChannelMessage(binaryMessage []byte, r Respo
 	}
 	message, err := b.codec.DecodeMessage(binaryMessage)
 	if err != nil {
-		return errors.Wrap(err, "failed to decode incomming message")
+		return errors.Wrap(err, "failed to decode incoming message")
 	}
 	reply, err := b.handler.HandleMessage(message)
 	if err != nil {

--- a/plugin/event-channel.go
+++ b/plugin/event-channel.go
@@ -47,7 +47,7 @@ func (e *EventChannel) Handle(handler StreamHandler) {
 func (e *EventChannel) handleChannelMessage(binaryMessage []byte, responseSender ResponseSender) (err error) {
 	methodCall, err := e.methodCodec.DecodeMethodCall(binaryMessage)
 	if err != nil {
-		return errors.Wrap(err, "failed to decode incomming message")
+		return errors.Wrap(err, "failed to decode incoming message")
 	}
 
 	if e.handler == nil {

--- a/plugin/method-channel.go
+++ b/plugin/method-channel.go
@@ -17,8 +17,9 @@ type MethodChannel struct {
 	channelName string
 	methodCodec MethodCodec
 
-	methods     map[string]methodHandlerRegistration
-	methodsLock sync.RWMutex
+	methods         map[string]methodHandlerRegistration
+	catchAllhandler MethodHandler
+	methodsLock     sync.RWMutex
 }
 
 type methodHandlerRegistration struct {
@@ -88,7 +89,10 @@ func (m *MethodChannel) Handle(methodName string, handler MethodHandler) {
 	m.methodsLock.Unlock()
 }
 
-// HandleFunc is a shorthand for m.Handle(MethodHandlerFunc(f))
+// HandleFunc is a shorthand for m.Handle("name", MethodHandlerFunc(f))
+//
+// The argument of the function f is an interface corresponding to the
+// MethodCall.Arguments values
 func (m *MethodChannel) HandleFunc(methodName string, f func(arguments interface{}) (reply interface{}, err error)) {
 	if f == nil {
 		m.Handle(methodName, nil)
@@ -113,7 +117,10 @@ func (m *MethodChannel) HandleSync(methodName string, handler MethodHandler) {
 	m.methodsLock.Unlock()
 }
 
-// HandleFuncSync is a shorthand for m.HandleSync(MethodHandlerFunc(f))
+// HandleFuncSync is a shorthand for m.HandleSync("name", MethodHandlerFunc(f))
+//
+// The argument of the function f is an interface corresponding to the
+// MethodCall.Arguments values
 func (m *MethodChannel) HandleFuncSync(methodName string, f func(arguments interface{}) (reply interface{}, err error)) {
 	if f == nil {
 		m.HandleSync(methodName, nil)
@@ -121,6 +128,27 @@ func (m *MethodChannel) HandleFuncSync(methodName string, f func(arguments inter
 	}
 
 	m.HandleSync(methodName, MethodHandlerFunc(f))
+}
+
+// CatchAllHandle registers a default method handler.
+// When no Handle are found, the handler provided in CatchAllHandle will be
+// used. If no CatchAllHandle is provided, a MissingPluginException exception
+// is sent when no handler is registered for a method name.
+//
+// Consecutive calls override any existing handler registration for (the name
+// of) this method. When given nil as handler, the previously registered
+// handler for a method is unregistered.
+func (m *MethodChannel) CatchAllHandle(handler MethodHandler) {
+	m.methodsLock.Lock()
+	m.catchAllhandler = handler
+	m.methodsLock.Unlock()
+}
+
+// CatchAllHandleFunc is a shorthand for m.CatchAllHandle(MethodHandlerFunc(f))
+//
+// The argument of the function f is a MethodCall struct
+func (m *MethodChannel) CatchAllHandleFunc(f func(arguments interface{}) (reply interface{}, err error)) {
+	m.CatchAllHandle(MethodHandlerFunc(f))
 }
 
 // handleChannelMessage decodes incoming binary message to a method call, calls the
@@ -135,43 +163,49 @@ func (m *MethodChannel) handleChannelMessage(binaryMessage []byte, responseSende
 	registration, registrationExists := m.methods[methodCall.Method]
 	m.methodsLock.RUnlock()
 	if !registrationExists {
+
+		if m.catchAllhandler != nil {
+			go m.handleMethodCall(m.catchAllhandler, methodCall.Method, methodCall, responseSender)
+			return nil
+		}
+
 		fmt.Printf("go-flutter: no method handler registered for method '%s' on channel '%s'\n", methodCall.Method, m.channelName)
 		responseSender.Send(nil)
 		return nil
 	}
 
 	if registration.sync {
-		m.handleMethodCall(registration.handler, methodCall, responseSender)
+		m.handleMethodCall(registration.handler, methodCall.Method, methodCall.Arguments, responseSender)
 	} else {
-		go m.handleMethodCall(registration.handler, methodCall, responseSender)
+		go m.handleMethodCall(registration.handler, methodCall.Method, methodCall.Arguments, responseSender)
 	}
 
 	return nil
 }
 
 // handleMethodCall handles the methodcall and sends a response.
-func (m *MethodChannel) handleMethodCall(handler MethodHandler, methodCall MethodCall, responseSender ResponseSender) {
+func (m *MethodChannel) handleMethodCall(handler MethodHandler, methodName string, methodArgs interface{}, responseSender ResponseSender) {
 	defer func() {
 		p := recover()
 		if p != nil {
-			fmt.Printf("go-flutter: recovered from panic while handling call for method '%s' on channel '%s': %v\n", methodCall.Method, m.channelName, p)
+			fmt.Printf("go-flutter: recovered from panic while handling call for method '%s' on channel '%s': %v\n", methodName, m.channelName, p)
 			debug.PrintStack()
 		}
 	}()
 
-	reply, err := handler.HandleMethod(methodCall.Arguments)
+	reply, err := handler.HandleMethod(methodArgs)
 	if err != nil {
-		fmt.Printf("go-flutter: handler for method '%s' on channel '%s' returned an error: %v\n", methodCall.Method, m.channelName, err)
+		fmt.Printf("go-flutter: handler for method '%s' on channel '%s' returned an error: %v\n", methodName, m.channelName, err)
 		binaryReply, err := m.methodCodec.EncodeErrorEnvelope("error", err.Error(), nil)
 		if err != nil {
-			fmt.Printf("go-flutter: failed to encode error envelope for method '%s' on channel '%s', error: %v\n", methodCall.Method, m.channelName, err)
+			fmt.Printf("go-flutter: failed to encode error envelope for method '%s' on channel '%s', error: %v\n", methodName, m.channelName, err)
 		}
 		responseSender.Send(binaryReply)
 		return
 	}
 	binaryReply, err := m.methodCodec.EncodeSuccessEnvelope(reply)
 	if err != nil {
-		fmt.Printf("go-flutter: failed to encode success envelope for method '%s' on channel '%s', error: %v\n", methodCall.Method, m.channelName, err)
+		fmt.Printf("go-flutter: failed to encode success envelope for method '%s' on channel '%s', error: %v\n", methodName, m.channelName, err)
 	}
 	responseSender.Send(binaryReply)
 }

--- a/plugin/method-channel.go
+++ b/plugin/method-channel.go
@@ -41,7 +41,7 @@ func NewMethodChannel(messenger BinaryMessenger, channelName string, methodCodec
 
 // InvokeMethod sends a methodcall to the binary messenger and waits for a
 // result. Results from the Flutter side are not yet implemented in the
-// embedder. Until then, InvokeMethod will always return nil as reult.
+// embedder. Until then, InvokeMethod will always return nil as result.
 // https://github.com/flutter/flutter/issues/18852
 func (m *MethodChannel) InvokeMethod(name string, arguments interface{}) (result interface{}, err error) {
 	encodedMessage, err := m.methodCodec.EncodeMethodCall(MethodCall{
@@ -72,7 +72,7 @@ func (m *MethodChannel) InvokeMethod(name string, arguments interface{}) (result
 //
 // Consecutive calls override any existing handler registration for (the name
 // of) this method. When given nil as handler, the previously registered
-// handler for a method is unregistrered.
+// handler for a method is unregistered.
 //
 // When no handler is registered for a method, it will be handled silently by
 // sending a nil reply which triggers the dart MissingPluginException exception.
@@ -128,7 +128,7 @@ func (m *MethodChannel) HandleFuncSync(methodName string, f func(arguments inter
 func (m *MethodChannel) handleChannelMessage(binaryMessage []byte, responseSender ResponseSender) (err error) {
 	methodCall, err := m.methodCodec.DecodeMethodCall(binaryMessage)
 	if err != nil {
-		return errors.Wrap(err, "failed to decode incomming message")
+		return errors.Wrap(err, "failed to decode incoming message")
 	}
 
 	m.methodsLock.RLock()


### PR DESCRIPTION
fixes #196 
IThis PR adds the functionality to set MethodHandler for unknown Method name.

Example:
```go
p.channel.CatchAllHandleFunc(p.pathPrefixTest)

func (p *Example) pathPrefixTest(methodCall interface{}) (reply interface{}, err error) {
	method := methodCall.(plugin.MethodCall)
	// return the randomized Method Name
	return method.Method, nil
}
```

Testing code:  https://github.com/go-flutter-desktop/examples/pull/14