### PR TITLE
Fix backspace on the entire input wrong behavior

### DIFF
--- a/textinput_model.go
+++ b/textinput_model.go
@@ -156,7 +156,7 @@ func (p *textinputPlugin) sliceLeftWord() {
 }
 
 func (p *textinputPlugin) sliceLeftLine() {
-	p.word = p.word[:0]
+	p.word = p.word[p.selectionBase:]
 	p.selectionBase = 0
 	p.selectionExtent = 0
 }


### PR DESCRIPTION
Previously if I had the cursor here and pressed `cmd` + `backspace`. It would delete the entire input. Which is wrong because backspace removes everything on the LEFT of the cursor and not right.

<img width="99" alt="Capture d’écran 2019-08-04 à 18 12 35" src="https://user-images.githubusercontent.com/17520006/62426320-85cac280-b6e3-11e9-93cc-756f56509548.png">
