### PR TITLE
Custom error codes on the plugin side

### DIFF
--- a/plugin/method-channel.go
+++ b/plugin/method-channel.go
@@ -213,7 +213,7 @@ func (m *MethodChannel) handleMethodCall(handler MethodHandler, methodName strin
 
 		var errorCode string
 		switch t := err.(type) {
-		case *PluginError:
+		case *Error:
 			errorCode = t.code
 		default:
 			errorCode = "error"
@@ -233,22 +233,22 @@ func (m *MethodChannel) handleMethodCall(handler MethodHandler, methodName strin
 	responseSender.Send(binaryReply)
 }
 
-// This error can be thrown from a go-flutter plugin. Useful if
-// you are interested in returning custom error codes.
-// If that is not the case, you can just throw normal Go 'error's
-type PluginError struct {
+// Error implement the Go error interface, can be thrown from a go-flutter
+// method channel plugin to return custom error codes.
+// Normal Go error can also be used, the error code will default to "error".
+type Error struct {
 	err  string
 	code string
 }
 
-// Needed to comply with the Golang 'error' interface
-func (e *PluginError) Error() string {
+// Error is needed to comply with the Golang error interface.
+func (e *Error) Error() string {
 	return e.err
 }
 
-// Create an error with an specific error code
-func NewPluginError(code string, err error) *PluginError {
-	pe := &PluginError{
+// NewError create an error with an specific error code.
+func NewError(code string, err error) *Error {
+	pe := &Error{
 		code: code,
 		err:  err.Error(),
 	}

--- a/plugin/method-channel.go
+++ b/plugin/method-channel.go
@@ -233,19 +233,24 @@ func (m *MethodChannel) handleMethodCall(handler MethodHandler, methodName strin
 	responseSender.Send(binaryReply)
 }
 
+// This error can be thrown from a go-flutter plugin. Useful if
+// you are interested in returning custom error codes.
+// If that is not the case, you can just throw normal Go 'error's
 type PluginError struct {
-	err    string
-	code   string
+	err  string
+	code string
 }
 
+// Needed to comply with the Golang 'error' interface
 func (e *PluginError) Error() string {
-    return e.err
+	return e.err
 }
 
-func NewPluginError(code string, err error) (*PluginError) {
+// Create an error with an specific error code
+func NewPluginError(code string, err error) *PluginError {
 	pe := &PluginError{
-		code:   code,
-		err: err.Error(),
+		code: code,
+		err:  err.Error(),
 	}
 	return pe
 }


### PR DESCRIPTION
There are Flutter plugins that use custom error codes when returning to the Dart side.
For instance, Sqflite [here](https://github.com/tekartik/sqflite/blob/53662bafb3ae074ab947ddce7dadb406f9753cf3/sqflite/android/src/main/java/com/tekartik/sqflite/SqflitePlugin.java#L217). 
It is a non breaking change.

I created another PR using this feature in the examples repo. [#28](https://github.com/go-flutter-desktop/examples/pull/28)

P.S: I tested it with go-flutter master as base since in beta it gives me the following error in my machine.
```
# github.com/go-flutter-desktop/go-flutter/embedder
/usr/lib64/gcc/x86_64-suse-linux/9/../../../../x86_64-suse-linux/bin/ld: $WORK/b037/_x003.o: in function `_cgo_3e7fb0d74f06_Cfunc_FlutterPlatformMessageReleaseResponseHandle':
/tmp/go-build/cgo-gcc-prolog:252: undefined reference to `FlutterPlatformMessageReleaseResponseHandle'
/usr/lib64/gcc/x86_64-suse-linux/9/../../../../x86_64-suse-linux/bin/ld: $WORK/b037/_x005.o: in function `createMessageResponseHandle':
../../../go-flutter/embedder/embedder_helper.c:73: undefined reference to `FlutterPlatformMessageCreateResponseHandle'
collect2: error: ld returned 1 exit status
hover: Updating go-flutter to latest version failed: exit status 2
```