### PR TITLE
fixes flutter foundation on minimization

### DIFF
--- a/glfw.go
+++ b/glfw.go
@@ -194,6 +194,7 @@ func (m *windowManager) glfwRefreshCallback(window *glfw.Window) {
 	width, _ := window.GetSize()
 	if width == 0 {
 		fmt.Println("go-flutter: Cannot calculate pixelsPerScreenCoordinate for zero-width window.")
+		return
 	} else {
 		m.pixelsPerScreenCoordinate = float64(widthPx) / float64(width)
 	}


### PR DESCRIPTION
When SendWindowMetricsEvent sends 0 Width/Height. The flutter foundation
reports an error. SendWindowMetricsEvent shouldn't send 0 Width/Height.

fixes #234 