### PR TITLE
downgrade OpenGL from 4.1 to 3.3

### DIFF
--- a/application.go
+++ b/application.go
@@ -99,8 +99,8 @@ func (a *Application) Run() error {
 		return errors.Errorf("invalid window mode %T", a.config.windowMode)
 	}
 
-	glfw.WindowHint(glfw.ContextVersionMajor, 4)
-	glfw.WindowHint(glfw.ContextVersionMinor, 1)
+	glfw.WindowHint(glfw.ContextVersionMajor, 3)
+	glfw.WindowHint(glfw.ContextVersionMinor, 3)
 	glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
 	glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)
 

--- a/texture-registry.go
+++ b/texture-registry.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/go-flutter-desktop/go-flutter/embedder"
-	"github.com/go-gl/gl/v4.6-core/gl"
+	"github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/go-gl/glfw/v3.2/glfw"
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
fixes #248 
downgrading from 4.x to 3.3 enable us target more devices without any cost.
