### PR TITLE
Select opengl

### DIFF
--- a/application.go
+++ b/application.go
@@ -208,7 +208,7 @@ func (a *Application) Run() error {
 		return true
 	}
 	a.engine.GLProcResolver = func(procName string) unsafe.Pointer {
-		return opengl.GetProcAddress(procName)
+		return glfw.GetProcAddress(procName)
 	}
 	a.engine.GLExternalTextureFrameCallback = texturer.handleExternalTexture
 

--- a/application.go
+++ b/application.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-flutter-desktop/go-flutter/embedder"
 	"github.com/go-flutter-desktop/go-flutter/internal/execpath"
+	"github.com/go-flutter-desktop/go-flutter/internal/opengl"
 )
 
 // Run executes a flutter application with the provided options.
@@ -99,10 +100,7 @@ func (a *Application) Run() error {
 		return errors.Errorf("invalid window mode %T", a.config.windowMode)
 	}
 
-	glfw.WindowHint(glfw.ContextVersionMajor, 3)
-	glfw.WindowHint(glfw.ContextVersionMinor, 3)
-	glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
-	glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)
+	opengl.GLFWWindowHint()
 
 	if a.config.windowInitialLocation.xpos != 0 {
 		// To create the window at a specific position, make it initially invisible
@@ -210,7 +208,7 @@ func (a *Application) Run() error {
 		return true
 	}
 	a.engine.GLProcResolver = func(procName string) unsafe.Pointer {
-		return glfw.GetProcAddress(procName)
+		return opengl.GetProcAddress(procName)
 	}
 	a.engine.GLExternalTextureFrameCallback = texturer.handleExternalTexture
 

--- a/application.go
+++ b/application.go
@@ -99,8 +99,8 @@ func (a *Application) Run() error {
 		return errors.Errorf("invalid window mode %T", a.config.windowMode)
 	}
 
-	glfw.WindowHint(glfw.ContextVersionMajor, 4)
-	glfw.WindowHint(glfw.ContextVersionMinor, 1)
+	glfw.WindowHint(glfw.ContextVersionMajor, 3)
+	glfw.WindowHint(glfw.ContextVersionMinor, 3)
 	glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
 	glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7 h1:SCYMcCJ89LjRGwEa0tRluNRiMjZHalQZrVrvTbPh+qw=
 github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7/go.mod h1:482civXOzJJCPzJ4ZOX/pwvXBWSnzD4OKMdH4ClKGbk=
@@ -6,8 +7,12 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1 h1:QbL/5oDUmRBzO9/Z7Seo
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/opengl/doc.go
+++ b/internal/opengl/doc.go
@@ -1,0 +1,9 @@
+// Package opengl wraps the go-gl/gl OpenGL bindings with a compile-time OpenGL
+// version selector.
+//
+// This package allows clients to target multiple version of OpenGL when
+// building go-flutter.
+// default is v3.3
+//
+// Golang build constraints are used to do the version selection.
+package opengl

--- a/internal/opengl/doc.go
+++ b/internal/opengl/doc.go
@@ -5,5 +5,5 @@
 // building go-flutter.
 // default is v3.3
 //
-// Golang build constraints are used to do the version selection.
+// Golang build constraints are used for version selection.
 package opengl

--- a/internal/opengl/opengl.go
+++ b/internal/opengl/opengl.go
@@ -1,5 +1,10 @@
-// The default version of OpenGL used by go-flutter.
+// +build !openglnone
+
 package opengl
+
+// The default version (3.3) of OpenGL used by go-flutter.
+// If you want to support other version, copy/pase this file, change the import
+// statement, add builds constraints and open a PR.
 
 import (
 	"unsafe"
@@ -9,8 +14,10 @@ import (
 )
 
 // const exposed to go-flutter
-const TEXTURE_2D = gl.TEXTURE_2D
-const RGBA8 = gl.RGBA8
+const (
+	TEXTURE2D = gl.TEXTURE_2D
+	RGBA8     = gl.RGBA8
+)
 
 // Init opengl
 func Init() error {
@@ -67,11 +74,4 @@ func GLFWWindowHint() {
 	glfw.WindowHint(glfw.ContextVersionMinor, 3)
 	glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
 	glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)
-
-}
-
-// GetProcAddress returns the address of the specified OpenGL or OpenGL ES core
-// or extension function, if it is supported by the current context.
-func GetProcAddress(namea string) unsafe.Pointer {
-	return gl.GlowGetProcAddress(namea)
 }

--- a/internal/opengl/opengl_none.go
+++ b/internal/opengl/opengl_none.go
@@ -1,0 +1,42 @@
+// +build openglnone
+
+package opengl
+
+// Don't link go-flutter against OpenGL, less-dependency at the cost of not
+// supporting external texture (eg: video_plugin)
+//
+// compile go-flutter with: hover build|run --opengl=none
+
+import (
+	"unsafe"
+)
+
+// const exposed to go-flutter
+const (
+	TEXTURE2D = 0
+	RGBA8     = 0
+)
+
+// Init opengl
+func Init() error { return nil }
+
+// DeleteTextures deletes named textures
+func DeleteTextures(n int32, textures *uint32) {}
+
+// CreateTexture creates a texture for go-flutter uses
+func CreateTexture(texture *uint32) {}
+
+// BindTexture binds a named texture to a texturing target
+func BindTexture(texture uint32) {}
+
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
+func Ptr(data interface{}) unsafe.Pointer { return nil }
+
+// TexImage2D specifies a two-dimensional texture image
+func TexImage2D(width, height int32, pixels unsafe.Pointer) {
+	panic("go-flutter: go-flutter wasn't compiled with support for external texture plugin.")
+}
+
+// GLFWWindowHint sets hints for the next call to CreateWindow.
+func GLFWWindowHint() {}

--- a/internal/opengl/version.go
+++ b/internal/opengl/version.go
@@ -1,0 +1,77 @@
+// The default version of OpenGL used by go-flutter.
+package opengl
+
+import (
+	"unsafe"
+
+	"github.com/go-gl/gl/v3.3-core/gl"
+	"github.com/go-gl/glfw/v3.2/glfw"
+)
+
+// const exposed to go-flutter
+const TEXTURE_2D = gl.TEXTURE_2D
+const RGBA8 = gl.RGBA8
+
+// Init opengl
+func Init() error {
+	return gl.Init()
+}
+
+// DeleteTextures deletes named textures
+func DeleteTextures(n int32, textures *uint32) {
+	gl.DeleteTextures(n, textures)
+}
+
+// CreateTexture creates a texture for go-flutter uses
+func CreateTexture(texture *uint32) {
+	gl.GenTextures(1, texture)
+	gl.BindTexture(gl.TEXTURE_2D, *texture)
+	// set the texture wrapping parameters
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_BORDER)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_BORDER)
+	// set texture filtering parameters
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+}
+
+// BindTexture binds a named texture to a texturing target
+func BindTexture(texture uint32) {
+	gl.BindTexture(gl.TEXTURE_2D, texture)
+}
+
+// Ptr takes a slice or pointer (to a singular scalar value or the first
+// element of an array or slice) and returns its GL-compatible address.
+func Ptr(data interface{}) unsafe.Pointer {
+	return gl.Ptr(data)
+}
+
+// TexImage2D specifies a two-dimensional texture image
+func TexImage2D(width, height int32, pixels unsafe.Pointer) {
+	// It the current flutter/engine can only support RGBA texture.
+	gl.TexImage2D(
+		gl.TEXTURE_2D,
+		0,
+		gl.RGBA,
+		width,
+		height,
+		0,
+		gl.RGBA,
+		gl.UNSIGNED_BYTE,
+		pixels,
+	)
+}
+
+// GLFWWindowHint sets hints for the next call to CreateWindow.
+func GLFWWindowHint() {
+	glfw.WindowHint(glfw.ContextVersionMajor, 3)
+	glfw.WindowHint(glfw.ContextVersionMinor, 3)
+	glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
+	glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)
+
+}
+
+// GetProcAddress returns the address of the specified OpenGL or OpenGL ES core
+// or extension function, if it is supported by the current context.
+func GetProcAddress(namea string) unsafe.Pointer {
+	return gl.GlowGetProcAddress(namea)
+}

--- a/texture-registry.go
+++ b/texture-registry.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/go-flutter-desktop/go-flutter/embedder"
-	"github.com/go-gl/gl/v3.3-core/gl"
+	"github.com/go-flutter-desktop/go-flutter/internal/opengl"
 	"github.com/go-gl/glfw/v3.2/glfw"
 	"github.com/pkg/errors"
 )
@@ -42,9 +42,9 @@ func newTextureRegistry(engine *embedder.FlutterEngine, window *glfw.Window) *Te
 
 func (t *TextureRegistry) init() error {
 	t.window.MakeContextCurrent()
-	// Important! Call gl.Init only under the presence of an active OpenGL context,
+	// Important! Call open.Init only under the presence of an active OpenGL context,
 	// i.e., after MakeContextCurrent.
-	if err := gl.Init(); err != nil {
+	if err := opengl.Init(); err != nil {
 		return errors.Wrap(err, "TextureRegistry gl init failed")
 	}
 	return nil
@@ -80,7 +80,7 @@ func (t *TextureRegistry) setTextureHandler(textureID int64, handler ExternalTex
 	if handler == nil {
 		texture := t.channels[textureID]
 		if texture != nil {
-			gl.DeleteTextures(1, &texture.texture)
+			opengl.DeleteTextures(1, &texture.texture)
 		}
 		delete(t.channels, textureID)
 	} else {
@@ -118,33 +118,21 @@ func (t *TextureRegistry) handleExternalTexture(textureID int64,
 	t.window.MakeContextCurrent()
 
 	if registration.texture == 0 {
-		gl.GenTextures(1, &registration.texture)
-		gl.BindTexture(gl.TEXTURE_2D, registration.texture)
-		// set the texture wrapping parameters
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_BORDER)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_BORDER)
-		// set texture filtering parameters
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+		opengl.CreateTexture(&registration.texture)
 	}
 
-	gl.BindTexture(gl.TEXTURE_2D, registration.texture)
-	// It seems that current flutter/engine can only support RGBA texture.
-	gl.TexImage2D(
-		gl.TEXTURE_2D,
-		0,
-		gl.RGBA,
+	opengl.BindTexture(registration.texture)
+
+	opengl.TexImage2D(
 		int32(pixelBuffer.Width),
 		int32(pixelBuffer.Height),
-		0,
-		gl.RGBA,
-		gl.UNSIGNED_BYTE,
-		gl.Ptr(pixelBuffer.Pix))
+		opengl.Ptr(pixelBuffer.Pix),
+	)
 
 	return &embedder.FlutterOpenGLTexture{
-		Target: gl.TEXTURE_2D,
+		Target: opengl.TEXTURE_2D,
 		Name:   registration.texture,
-		Format: gl.RGBA8,
+		Format: opengl.RGBA8,
 	}
 
 }

--- a/texture-registry.go
+++ b/texture-registry.go
@@ -130,7 +130,7 @@ func (t *TextureRegistry) handleExternalTexture(textureID int64,
 	)
 
 	return &embedder.FlutterOpenGLTexture{
-		Target: opengl.TEXTURE_2D,
+		Target: opengl.TEXTURE2D,
 		Name:   registration.texture,
 		Format: opengl.RGBA8,
 	}

--- a/texture-registry.go
+++ b/texture-registry.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	"github.com/go-flutter-desktop/go-flutter/embedder"
-	"github.com/go-gl/gl/v4.6-core/gl"
+	"github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/go-gl/glfw/v3.2/glfw"
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
Select the OpenGL version to use.

wraps the go-gl/gl lib in a internal package with build constrains to
let the user choose which go-gl/gl version he desire.

support 3.3(default) and none.

When the build tag is set to none, no dependency to go-gl/gl is
required, but texture plugins will not be supported.

related hover PR: https://github.com/go-flutter-desktop/hover/pull/24