### PR TITLE
feature: add global build constant values

### DIFF
--- a/build-constant.go
+++ b/build-constant.go
@@ -1,72 +1,19 @@
 package flutter
 
 // Compile configuration constants persistent across all flutter.Application.
-// The values of config(option.go) can change between flutter.Run calls, this
-// struct contains informations that needs to be access globally, without
+// The values of config(option.go) can change between flutter.Run calls, those
+// values contains informations that needs to be access globally, without
 // requiring an flutter.Application.
 //
-// Those value may be setted by hover during the 'Compiling 'go-flutter' and plugins' phase.
-type buildConstant struct {
-	projectVersion   string
-	projectName      string
-	goFlutterVersion string
-	organizationName string
-}
-
-var buildConfig = buildConstant{}
-
-// SetProjectVersion a string used as the project projectVersion number.
-//
-// This value is setted by hover with the name attribute available in the
-// pubspec.yaml file.
-func SetProjectVersion(projectVersion string) {
-	buildConfig.projectVersion = projectVersion
-}
-
-// ProjectVersion return the project version number.
-func ProjectVersion() string {
-	return buildConfig.projectVersion
-}
-
-// AppName return the project projectVersion number.
-func AppName() string {
-	return buildConfig.projectName
-}
-
-// SetAppName a string used as the project app name.
-//
-// This value is setted by hover with the name attribute available in the
-// pubspec.yaml file.
-func SetAppName(projectName string) {
-	buildConfig.projectName = projectName
-}
-
-// PlatformVersion return the go-flutter projectVersion number.
-func PlatformVersion() string {
-	return buildConfig.goFlutterVersion
-}
-
-// SetPlatformVersion a string used as the go-flutter projectVersion number.
-//
-// This value is setted by hover with the version attribute available in the
-// pubspec.yaml file.
-func SetPlatformVersion(version string) {
-	buildConfig.goFlutterVersion = version
-}
-
-// OrganizationName return the project Organization name, (Using hover, it's
-// equal the flag org value `flutter create --org tld.domain`).
-// Default to 'com.example'
-func OrganizationName() string {
-	return buildConfig.organizationName
-}
-
-// SetOrganizationName a string used to represent the organization responsible
-// for your Flutter project, in reverse domain name notation.
-//
-// This value is setted by hover with the xml attribute /manifest[@package]
-// available in the android/app/src/main/AndroidManifest.xml file.
-// Default to 'com.example'
-func SetOrganizationName(name string) {
-	buildConfig.organizationName = name
-}
+// Values overwritten by hover during the 'Compiling 'go-flutter' and
+// plugins' phase.
+var (
+	// ProjectVersion contains the version of the build
+	ProjectVersion = "unknown"
+	// ProjectVersion contains the version of the go-flutter been used
+	PlatformVersion = "unknown"
+	// ProjectName contains the application name
+	ProjectName = "unknown"
+	// OrganizationName contains the package org name, (Can by set upon flutter create (--org flag))
+	OrganizationName = "unknown"
+)

--- a/build-constant.go
+++ b/build-constant.go
@@ -1,0 +1,72 @@
+package flutter
+
+// Compile configuration constants persistent across all flutter.Application.
+// The values of config(option.go) can change between flutter.Run calls, this
+// struct contains informations that needs to be access globally, without
+// requiring an flutter.Application.
+//
+// Those value may be setted by hover during the 'Compiling 'go-flutter' and plugins' phase.
+type buildConstant struct {
+	projectVersion   string
+	projectName      string
+	goFlutterVersion string
+	organizationName string
+}
+
+var buildConfig = buildConstant{}
+
+// SetProjectVersion a string used as the project projectVersion number.
+//
+// This value is setted by hover with the name attribute available in the
+// pubspec.yaml file.
+func SetProjectVersion(projectVersion string) {
+	buildConfig.projectVersion = projectVersion
+}
+
+// ProjectVersion return the project version number.
+func ProjectVersion() string {
+	return buildConfig.projectVersion
+}
+
+// AppName return the project projectVersion number.
+func AppName() string {
+	return buildConfig.projectName
+}
+
+// SetAppName a string used as the project app name.
+//
+// This value is setted by hover with the name attribute available in the
+// pubspec.yaml file.
+func SetAppName(projectName string) {
+	buildConfig.projectName = projectName
+}
+
+// PlatformVersion return the go-flutter projectVersion number.
+func PlatformVersion() string {
+	return buildConfig.goFlutterVersion
+}
+
+// SetPlatformVersion a string used as the go-flutter projectVersion number.
+//
+// This value is setted by hover with the version attribute available in the
+// pubspec.yaml file.
+func SetPlatformVersion(version string) {
+	buildConfig.goFlutterVersion = version
+}
+
+// OrganizationName return the project Organization name, (Using hover, it's
+// equal the flag org value `flutter create --org tld.domain`).
+// Default to 'com.example'
+func OrganizationName() string {
+	return buildConfig.organizationName
+}
+
+// SetOrganizationName a string used to represent the organization responsible
+// for your Flutter project, in reverse domain name notation.
+//
+// This value is setted by hover with the xml attribute /manifest[@package]
+// available in the android/app/src/main/AndroidManifest.xml file.
+// Default to 'com.example'
+func SetOrganizationName(name string) {
+	buildConfig.organizationName = name
+}

--- a/build-constant.go
+++ b/build-constant.go
@@ -14,6 +14,6 @@ var (
 	PlatformVersion = "unknown"
 	// ProjectName contains the application name
 	ProjectName = "unknown"
-	// OrganizationName contains the package org name, (Can by set upon flutter create (--org flag))
-	OrganizationName = "unknown"
+	// ProjectOrganizationName contains the package org name, (Can by set upon flutter create (--org flag))
+	ProjectOrganizationName = "unknown"
 )


### PR DESCRIPTION
In the same way an android application can access the:
  - packageName(com.example.appName)
  - appName(appName)
  - version(context.getPackageManager().getPackageInfo(context.getPackageName(),
  0).versionName)

Add global values that can retrieve those informations,
this is necessary for the making of the (flutter maintained)
[package_info](https://github.com/flutter/plugins/tree/master/packages/package_info)
flutter plugin.

This will also came useful for the future `hover init-plugin` command,
as the default `flutter create --template=plugin plugin_name` creates a
template plugin that retrieve the `android.os.Build.VERSION.RELEASE`
constant on android.  The mapping value for go-flutter is
`flutter.PlatformVersion()` (go-flutter release used for the project)