### PR TITLE
feature: debounce some GLFW callbacks

### DIFF
--- a/application.go
+++ b/application.go
@@ -286,8 +286,7 @@ func (a *Application) Run() error {
 	glfwDebouceTasker := tasker.New()
 	debounced := debounce.New(50 * time.Millisecond)
 	// SetPosCallback is called when the window is moved, this directly calls
-	// glfwRefreshCallback in order to recalculate DPI.
-	// TODO: when moving to glfw 3.3, use glfwSetWindowContentScaleCallback
+	// glfwRefreshCallback in order to redraw and avoid transparent scene.
 	a.window.SetPosCallback(func(window *glfw.Window, xpos int, ypos int) {
 		debounced(func() {
 			glfwDebouceTasker.Do(func() {
@@ -295,6 +294,7 @@ func (a *Application) Run() error {
 			})
 		})
 	})
+	// TODO: when moving to glfw 3.3, also use glfwSetWindowContentScaleCallback
 
 	// Attach glfw window callbacks for text input
 	a.window.SetKeyCallback(

--- a/glfw.go
+++ b/glfw.go
@@ -193,12 +193,6 @@ func (m *windowManager) glfwScrollCallback(window *glfw.Window, xoff float64, yo
 	m.sendPointerEventScroll(window, xoff*scrollModifier, yoff*scrollModifier)
 }
 
-// glfwPosCallback is called when the window is moved, this directly calls
-// glfwRefreshCallback in order to recalculate DPI.
-func (m *windowManager) glfwPosCallback(window *glfw.Window, xpos int, ypos int) {
-	m.glfwRefreshCallback(window)
-}
-
 // glfwRefreshCallback is called when the window needs a reresh, this
 // can occur when the window is resized, was covered by another window, etc.
 // When forcedPixelratio is zero, the forcedPixelratio communicated to the

--- a/internal/debounce/debounce.go
+++ b/internal/debounce/debounce.go
@@ -1,0 +1,55 @@
+// Copyright © 2019 Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+// Package debounce provides a debouncer func. The most typical use case would be
+// the user typing a text into a form; the UI needs an update, but let's wait for
+// a break.
+//
+// Copied from https://github.com/bep/debounce/blob/master/debounce.go
+// modified to support an glfw.Window argument.
+package debounce
+
+import (
+	"sync"
+	"time"
+
+	"github.com/go-flutter-desktop/go-flutter/internal/tasker"
+	"github.com/go-gl/glfw/v3.2/glfw"
+)
+
+// New returns a debounced function that takes another functions as its argument.
+// This function will be called when the debounced function stops being called
+// for the given duration.
+// The debounced function can be invoked with different functions, if needed,
+// the last one will win.
+func New(after time.Duration, glfwTasker *tasker.Tasker) func(f func(window *glfw.Window), window *glfw.Window) {
+	d := &debouncer{after: after, glfwTasker: glfwTasker}
+
+	return func(f func(window *glfw.Window), window *glfw.Window) {
+		d.add(f, window)
+	}
+}
+
+type debouncer struct {
+	mu         sync.Mutex
+	after      time.Duration
+	timer      *time.Timer
+	glfwTasker *tasker.Tasker
+}
+
+func (d *debouncer) add(f func(window *glfw.Window), window *glfw.Window) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.timer != nil {
+		d.timer.Stop()
+	}
+	d.timer = time.AfterFunc(d.after, func() {
+		// needs to run on main thread
+		d.glfwTasker.Do(func() {
+			f(window)
+		})
+	})
+}


### PR DESCRIPTION
The window drag callback is called at high rate when the related event occur.  

Currently, upon handling this CB, we send to the `WindowMetricsEvent` (PixelRatio / height / width) to the embedding API and the flutter/engine redraw the scene causing all widgets to be redrawn.
This operation is quite heavy and during the widget redraw, network call can be made. (using https://pub.dev/packages/provider it's is the case)

This commit debounce calls to the GLFW that triggers widget redraw.

```
$ hover run -b "@feature/debouce-glfw-events"