### PR TITLE
add callback for text show/hide

### DIFF
--- a/option.go
+++ b/option.go
@@ -245,3 +245,27 @@ type KeyboardShortcuts struct {
 	Paste     glfw.Key
 	SelectAll glfw.Key
 }
+
+// VirtualKeyboardShow sets an func called when the flutter framework want to
+// show the keyboard.
+// This Option is interesting for people wanting to display the on-screen
+// keyboard on TextField focus.
+// It's up to the flutter developer to implement (or not) this function with
+// the OS related call.
+func VirtualKeyboardShow(showCallback func()) Option {
+	return func(c *config) {
+		// Reference the callback to the platform plugin (singleton) responsible
+		// for textinput.
+		defaultTextinputPlugin.virtualKeyboardShow = showCallback
+	}
+}
+
+// VirtualKeyboardHide sets an func called when the flutter framework want to
+// hide the keyboard.
+func VirtualKeyboardHide(hideCallback func()) Option {
+	return func(c *config) {
+		// Reference the callback to the platform plugin (singleton) responsible
+		// for textinput.
+		defaultTextinputPlugin.virtualKeyboardHide = hideCallback
+	}
+}

--- a/textinput.go
+++ b/textinput.go
@@ -26,6 +26,9 @@ type textinputPlugin struct {
 	word            []rune
 	selectionBase   int
 	selectionExtent int
+
+	virtualKeyboardShow func()
+	virtualKeyboardHide func()
 }
 
 // keyboardShortcutsGLFW handle glfw.ModifierKey from glfwKeyCallback.
@@ -51,9 +54,18 @@ func (p *textinputPlugin) InitPluginGLFW(window *glfw.Window) error {
 	p.channel.HandleFuncSync("TextInput.setClient", p.handleSetClient)
 	p.channel.HandleFuncSync("TextInput.clearClient", p.handleClearClient)
 	p.channel.HandleFuncSync("TextInput.setEditingState", p.handleSetEditingState)
-	// Ignored: Desktop's don't have a virtual keyboard, so there is no need to show or hide it
-	p.channel.HandleFuncSync("TextInput.show", func(_ interface{}) (interface{}, error) { return nil, nil })
-	p.channel.HandleFuncSync("TextInput.hide", func(_ interface{}) (interface{}, error) { return nil, nil })
+	p.channel.HandleFunc("TextInput.show", func(_ interface{}) (interface{}, error) {
+		if p.virtualKeyboardShow != nil {
+			p.virtualKeyboardShow()
+		}
+		return nil, nil 
+	})
+	p.channel.HandleFunc("TextInput.hide", func(_ interface{}) (interface{}, error) {
+		if p.virtualKeyboardHide != nil {
+			p.virtualKeyboardHide()
+		}
+		return nil, nil
+	})
 	return nil
 }
 


### PR DESCRIPTION
Those callback are useful when wanting to display the OS virtual keyboard.

fixes #274

Linux example:
```go
package main

// the file virtual_keyboard_linux.go is used to show the 'onboard'
// vitrual keyboard upon text input.

import (
	"os/exec"
	flutter "github.com/go-flutter-desktop/go-flutter"
)

var onBoard = exec.Command("onboard")

func init() {
	options = append(options,
		flutter.VirtualKeyboardShow(func(){
			err := onBoard.Start()
			if err != nil {
				return
			}
		}),
	)
}
```