### PR TITLE
docs: update Mac OS CGO_LDFLAGS for embedder readme

### DIFF
--- a/embedder/README.md
+++ b/embedder/README.md
@@ -6,6 +6,7 @@ This package wraps the [Flutter embedder API](https://raw.githubusercontent.com/
 
 To build this package set the `CGO_LDFLAGS` and run `go build`. For example:
 
+On Linux:
 ```bash
 export CGO_LDFLAGS="-L/home/${HOME}/.cache/hover/engine/linux/"
 go build
@@ -14,6 +15,12 @@ go build
 To build this package on Mac OS
 ```bash
 export CGO_LDFLAGS="-F ${HOME}/Library/Caches/hover/engine/darwin"
+go build
+```
+
+To build this package on Windows
+```cmd
+set CGO_LDFLAGS="-L%HOMEPATH%/.cache/hover/engine/windows/"
 go build
 ```
 

--- a/embedder/README.md
+++ b/embedder/README.md
@@ -11,4 +11,10 @@ export CGO_LDFLAGS="-L/home/${HOME}/.cache/hover/engine/linux/"
 go build
 ```
 
+To build this package on Mac OS
+```bash
+export CGO_LDFLAGS="-F ${HOME}/Library/Caches/hover/engine/darwin"
+go build
+```
+
 This works if [hover](https://github.com/go-flutter-desktop/hover) has cached the flutter engine for the local user.


### PR DESCRIPTION
https://github.com/go-flutter-desktop/go-flutter/issues/302

hover cache path is different on darwin