### PR TITLE
Add Option to enable always on top for the application window

### DIFF
--- a/application.go
+++ b/application.go
@@ -116,6 +116,10 @@ func (a *Application) Run() error {
 		glfw.WindowHint(glfw.Visible, glfw.False)
 	}
 
+	if a.config.alwaysOnTop {
+		glfw.WindowHint(glfw.Floating, glfw.True)
+	}
+
 	a.window, err = glfw.CreateWindow(a.config.windowInitialDimensions.width, a.config.windowInitialDimensions.height, "Loading..", monitor, nil)
 	if err != nil {
 		return errors.Wrap(err, "creating glfw window")

--- a/option.go
+++ b/option.go
@@ -19,6 +19,8 @@ type config struct {
 	windowDimensionLimits   windowDimensionLimits
 	windowMode              windowMode
 
+	alwaysOnTop             bool
+
 	forcePixelRatio float64
 	keyboardLayout  KeyboardShortcuts
 
@@ -51,6 +53,7 @@ var defaultApplicationConfig = config{
 	},
 	keyboardLayout: KeyboardQwertyLayout,
 	windowMode:     WindowModeDefault,
+	alwaysOnTop:    false,
 }
 
 // Option for Application
@@ -167,6 +170,13 @@ func WindowIcon(iconProivder func() ([]image.Image, error)) Option {
 func ForcePixelRatio(ratio float64) Option {
 	return func(c *config) {
 		c.forcePixelRatio = ratio
+	}
+}
+
+// AlwaysOnTop sets the application window to be always on top of other windows
+func AlwaysOnTop(enabled bool) Option {
+	return func(c *config) {
+		c.alwaysOnTop = enabled
 	}
 }
 


### PR DESCRIPTION
For some workflows it's useful to have the application window running always on top (similarly to what the Android Emulator allows). 
So this PR implements another `Option` that when enabled sets the window to be on top of all others. To keep the same behaviour it defaults to `false`