### PR TITLE
fix: paste not working in macOS

### DIFF
--- a/textinput.go
+++ b/textinput.go
@@ -3,6 +3,7 @@ package flutter
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"unicode"
 
 	"github.com/go-flutter-desktop/go-flutter/plugin"
@@ -198,6 +199,15 @@ func (p *textinputPlugin) glfwKeyCallback(window *glfw.Window, key glfw.Key, sca
 				_, _, selectedContent := p.getSelectedText()
 				window.SetClipboardString(selectedContent)
 				p.removeSelectedText()
+			}
+
+		case p.keyboardLayout.Paste:
+			if runtime.GOOS != "darwin" {
+				break
+			}
+			if keyboardShortcutBind.isModifier() {
+				clpString := window.GetClipboardString()
+				p.addChar([]rune(clpString))
 			}
 		}
 		p.updateEditingState()


### PR DESCRIPTION
As mentioned on https://github.com/go-flutter-desktop/go-flutter/issues/349#issuecomment-580822056, v0.35.1 at https://github.com/go-flutter-desktop/go-flutter/commit/ab1d16df99d69ae195bc4cece1a55b80dab40690 broke pasting at least on macOS.

Would a "fix" like this be acceptable? If not, is there a better approach to properly fix this?

ps. Don't have a windows box atm to test regressions. Need to download a vm at some point.