### PR TITLE
Expose GLFW window focus callback via option

### DIFF
--- a/application.go
+++ b/application.go
@@ -256,6 +256,13 @@ func (a *Application) Run() error {
 		os.Exit(1)
 	}
 
+	// Register window focus callback
+	if a.config.windowFocusCallback != nil {
+		a.window.SetFocusCallback(func(_ *glfw.Window, focused bool) {
+			a.config.windowFocusCallback(focused)
+		})
+	}
+
 	// Register plugins
 	for _, p := range a.config.plugins {
 		err = p.InitPlugin(messenger)

--- a/option.go
+++ b/option.go
@@ -19,6 +19,7 @@ type config struct {
 	windowDimensionLimits   windowDimensionLimits
 	windowMode              windowMode
 	windowAlwaysOnTop       bool
+	windowFocusCallback     func(focused bool)
 
 	forcePixelRatio float64
 	keyboardLayout  KeyboardShortcuts
@@ -176,6 +177,14 @@ func ForcePixelRatio(ratio float64) Option {
 func WindowAlwaysOnTop(enabled bool) Option {
 	return func(c *config) {
 		c.windowAlwaysOnTop = enabled
+	}
+}
+
+// WindowFocusCallback sets the focus callback of the window, which is called
+// when the window gains or loses focus.
+func WindowFocusCallback(h func(bool)) Option {
+	return func(c *config) {
+		c.windowFocusCallback = h
 	}
 }
 


### PR DESCRIPTION
I needed a way to detect whether the window got in or out of focus in order to enable/disable notifications, re-check connections and other things, so I wanted to expose the GLFW `SetFocusCallback` method.

Please let me know if there is a better way of doing this or feel free to close the PR if you are not interested in merging something like this.

Thank you :)