### PR TITLE
fixes: #345 InvokeMethodWithReply segfault

### DIFF
--- a/embedder/embedder.go
+++ b/embedder/embedder.go
@@ -46,10 +46,6 @@ type FlutterOpenGLTexture struct {
 type FlutterTask = C.FlutterTask
 
 // FlutterEngine corresponds to the C.FlutterEngine with his associated callback's method.
-//
-// Trick the panic error:
-// cgo argument has Go pointer to Go pointer
-// GoType(KeepAlive) -> unsafe.Pointer -> uintptr(KeepAlive) -> unsafe.Pointer(Pass to the C function) <- uintptr <- unsafe.Pointer <- GoType
 type FlutterEngine struct {
 	// Flutter Engine.
 	Engine C.FlutterEngine
@@ -350,10 +346,6 @@ func (flu *FlutterEngine) MarkExternalTextureFrameAvailable(textureID int64) Res
 
 // DataCallback is a function called when a PlatformMessage response send back
 // to the embedder.
-//
-// Trick the panic error:
-// cgo argument has Go pointer to Go pointer
-// GoType(KeepAlive) -> unsafe.Pointer -> uintptr(KeepAlive) -> unsafe.Pointer(Pass to the C function) <- uintptr <- unsafe.Pointer <- GoType
 type DataCallback struct {
 	// Handle func
 	Handle func(binaryReply []byte)

--- a/embedder/embedder_proxy.go
+++ b/embedder/embedder_proxy.go
@@ -97,6 +97,6 @@ func proxy_post_task_callback(task C.FlutterTask, targetTimeNanos C.uint64_t, us
 //export proxy_desktop_binary_reply
 func proxy_desktop_binary_reply(data *C.uint8_t, dataSize C.size_t, userData unsafe.Pointer) {
 	callbackPointer := *(*uintptr)(userData)
-	handler := *(*DataCallback)(unsafe.Pointer(callbackPointer))
-	handler(C.GoBytes(unsafe.Pointer(data), C.int(dataSize)))
+	callback := (*DataCallback)(unsafe.Pointer(callbackPointer))
+	callback.Handle(C.GoBytes(unsafe.Pointer(data), C.int(dataSize)))
 }


### PR DESCRIPTION
The callback function used to retrieve the value of the reply was
free-ed by the Golang GC.
This was quite hard to fix, had to uses runtime.KeepAlive on a struct
that contains the callback function.
runtime.KeepAlive, ensures that the object is not freed, and its
finalizer is not run, before the point in the program where KeepAlive is
called. Since the returned value is obtained with the callback function,
I used the `defer` keyword to make the function as not used for the gc
once we have the reply value.