### PR TITLE
fixes #133: same task runner for platform&render

### DIFF
--- a/application.go
+++ b/application.go
@@ -251,6 +251,8 @@ func (a *Application) Run() error {
 			fmt.Printf("go-flutter: engine.Run() returned result code %d (invalid library version)\n", result)
 		case embedder.ResultInvalidArguments:
 			fmt.Printf("go-flutter: engine.Run() returned result code %d (invalid arguments)\n", result)
+		case embedder.ResultInternalInconsistency:
+			fmt.Printf("go-flutter: engine.Run() returned result code %d (internal inconsistency)\n", result)
 		default:
 			fmt.Printf("go-flutter: engine.Run() returned result code %d (unknown result code)\n", result)
 		}

--- a/embedder/embedder.go
+++ b/embedder/embedder.go
@@ -30,6 +30,7 @@ const (
 	ResultSuccess               Result = C.kSuccess
 	ResultInvalidLibraryVersion Result = C.kInvalidLibraryVersion
 	ResultInvalidArguments      Result = C.kInvalidArguments
+	ResultInternalInconsistency Result = C.kInternalInconsistency
 	ResultEngineNotRunning      Result = -1
 )
 

--- a/embedder/embedder_helper.c
+++ b/embedder/embedder_helper.c
@@ -51,7 +51,9 @@ FlutterEngineResult runFlutter(void *user_data, FlutterEngine *engine, FlutterPr
 
   FlutterCustomTaskRunners custom_task_runners = {};
   custom_task_runners.struct_size = sizeof(FlutterCustomTaskRunners);
+  // Render task and platform task are handled by the same TaskRunner
   custom_task_runners.platform_task_runner = &platform_task_runner;
+  custom_task_runners.render_task_runner = &platform_task_runner;
   Args->custom_task_runners = &custom_task_runners;
 
   return FlutterEngineRun(FLUTTER_ENGINE_VERSION, &config, Args, user_data,

--- a/event-loop.go
+++ b/event-loop.go
@@ -24,7 +24,7 @@ type EventLoop struct {
 	// timeout for non-Rendering events that needs to be processed in a polling manner
 	platformMessageRefreshRate time.Duration
 
-	// indetifer for the current thread
+	// identifier for the current thread
 	mainThreadID int64
 }
 

--- a/event-loop.go
+++ b/event-loop.go
@@ -7,11 +7,12 @@ import (
 	"time"
 
 	"github.com/go-flutter-desktop/go-flutter/embedder"
+	"github.com/go-flutter-desktop/go-flutter/internal/currentthread"
 	"github.com/go-flutter-desktop/go-flutter/internal/priorityqueue"
 )
 
 // EventLoop is a event loop for the main thread that allows for delayed task
-// execution.()
+// execution.
 type EventLoop struct {
 	// store the task (event) by their priorities
 	priorityqueue *priorityqueue.PriorityQueue
@@ -22,10 +23,11 @@ type EventLoop struct {
 
 	// timeout for non-Rendering events that needs to be processed in a polling manner
 	platformMessageRefreshRate time.Duration
+
+	// indetifer for the current thread
+	mainThreadID int64
 }
 
-// newEventLoop must ALWAYS be called if the calling goroutine is
-// `runtime.LockOSThread()`
 func newEventLoop(postEmptyEvent func(), onExpiredTask func(*embedder.FlutterTask) embedder.Result) *EventLoop {
 	pq := priorityqueue.NewPriorityQueue()
 	heap.Init(pq)
@@ -33,6 +35,7 @@ func newEventLoop(postEmptyEvent func(), onExpiredTask func(*embedder.FlutterTas
 		priorityqueue:  pq,
 		postEmptyEvent: postEmptyEvent,
 		onExpiredTask:  onExpiredTask,
+		mainThreadID:   currentthread.ID(),
 
 		// 25 Millisecond is arbitrary value, not too high (adds too much delay to
 		// platform messages) and not too low (heavy CPU consumption).
@@ -46,17 +49,10 @@ func newEventLoop(postEmptyEvent func(), onExpiredTask func(*embedder.FlutterTas
 	}
 }
 
-// RunOnCurrentThread FlutterDocs:
-//   May be called from any thread. Should return true if tasks posted on the
-//   calling thread will be run on that same thread.
-//
-// The functions PostTask and onExpiredTask should be called from the same
-// thread, this is ensured if the creation of the event loop (through
-// `newEventLoop`) and the PostTask callback (through
-// `a.engine.TaskRunnerPostTask = eventLoop.PostTask`) are done on a calling
-// goroutine which always execute in that thread (`runtime.LockOSThread()`).
+// RunOnCurrentThread return true if tasks posted on the
+// calling thread will be run on that same thread.
 func (t *EventLoop) RunOnCurrentThread() bool {
-	return true
+	return currentthread.ID() == t.mainThreadID
 }
 
 // PostTask posts a Flutter engine tasks to the event loop for delayed execution.

--- a/internal/currentthread/thread-id.go
+++ b/internal/currentthread/thread-id.go
@@ -1,0 +1,30 @@
+// Package currentthread gives you access to the underlying thread id.
+package currentthread
+
+// //
+// // Extracted from TinyCThread, a minimalist, portable, threading library for C
+// //
+//
+// /* Platform specific includes */
+// #if defined(_WIN32) || defined(__WIN32__) || defined(__WINDOWS__)
+//   #include <windows.h>
+//   typedef HANDLE thrd_t;
+// #else
+//   #include <pthread.h>
+//   typedef pthread_t thrd_t;
+// #endif
+//
+// thrd_t thrd_current(void) {
+//   #if defined(_WIN32) || defined(__WIN32__) || defined(__WINDOWS__)
+//     return GetCurrentThread();
+//   #else
+//     return pthread_self();
+//   #endif
+// }
+// size_t getCurrentTheradID() { return (size_t)thrd_current(); }
+import "C"
+
+// ID returns the id of the current thread
+func ID() int64 {
+	return (int64)(C.getCurrentTheradID())
+}

--- a/internal/currentthread/thread-id.go
+++ b/internal/currentthread/thread-id.go
@@ -21,10 +21,10 @@ package currentthread
 //     return pthread_self();
 //   #endif
 // }
-// size_t getCurrentTheradID() { return (size_t)thrd_current(); }
+// size_t getCurrentThreadID() { return (size_t)thrd_current(); }
 import "C"
 
 // ID returns the id of the current thread
 func ID() int64 {
-	return (int64)(C.getCurrentTheradID())
+	return (int64)(C.getCurrentThreadID())
 }


### PR DESCRIPTION
rework of the last atempt: https://github.com/go-flutter-desktop/go-flutter/pull/329
Had to use a new internal package to query thread ID.
pakcage currentthread is compatible with windows (tested on the very old: gcc.exe (tdm64-1) 5.1.0) (won't have the same issue as in: https://github.com/go-flutter-desktop/go-flutter/issues/245)