### PR TITLE
Add TextInput stub implementations

### DIFF
--- a/textinput.go
+++ b/textinput.go
@@ -52,6 +52,9 @@ func (p *textinputPlugin) InitPlugin(messenger plugin.BinaryMessenger) error {
 func (p *textinputPlugin) InitPluginGLFW(window *glfw.Window) error {
 	p.window = window
 	p.channel = plugin.NewMethodChannel(p.messenger, textinputChannelName, plugin.JSONMethodCodec{})
+	p.channel.HandleFunc("TextInput.setEditableSizeAndTransform", func(arguments interface{}) (reply interface{}, err error) { return nil, nil })
+	p.channel.HandleFunc("TextInput.requestAutofill", func(arguments interface{}) (reply interface{}, err error) { return nil, nil })
+	p.channel.HandleFunc("TextInput.setStyle", func(arguments interface{}) (reply interface{}, err error) { return nil, nil })
 	p.channel.HandleFuncSync("TextInput.setClient", p.handleSetClient)
 	p.channel.HandleFuncSync("TextInput.clearClient", p.handleClearClient)
 	p.channel.HandleFuncSync("TextInput.setEditingState", p.handleSetEditingState)


### PR DESCRIPTION
Really annoying when using TextFields in my app to get the console spammed by missing handlers.