### PR TITLE
Add company/cases section on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Flutter itself is a relatively young project. Its framework and engine are updat
 
 Updating Go is simple and Go [seldomly has backwards-incompatible changes](https://golang.org/doc/go1compat). This project remains compatible with the [latest Go stable release](https://golang.org/dl/).
 
+### Cases
+
+Companies using `Go Flutter`:
+
+- [Nubank](https://nubank.com.br/en/)
+
 ### GLFW version
 
 This project uses go-gl/glfw for GLFW v3.3.


### PR DESCRIPTION
Hey, I was wondering that would be nice to have a section on hover with cases and companies that use `hover`/`Go Flutter`.
If you agreed in adding this section, I added the company where I work, [Nubank](https://nubank.com.br/en/), Latin America's Largest Financial Institution. Here we use hover as the base for our flutter development and it works really well.
https://medium.com/building-nubank/https-medium-com-freire-why-nubank-chose-flutter-61b80b568772

Let me know what you think