### PR TITLE
Option to pass escape events to the app instead of popping route

### DIFF
--- a/application.go
+++ b/application.go
@@ -322,6 +322,7 @@ func (a *Application) Run() error {
 	})
 
 	// Attach glfw window callbacks for text input
+	defaultTextinputPlugin.backOnEscape = a.config.backOnEscape
 	a.window.SetKeyCallback(
 		func(window *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
 			defaultTextinputPlugin.glfwKeyCallback(window, key, scancode, action, mods)

--- a/option.go
+++ b/option.go
@@ -23,6 +23,8 @@ type config struct {
 	windowAlwaysOnTop       bool
 	windowTransparent       bool
 
+	backOnEscape bool
+
 	forcePixelRatio float64
 	scrollAmount    float64
 
@@ -63,6 +65,8 @@ func newApplicationConfig() config {
 		windowAlwaysOnTop: false,
 		windowTransparent: false,
 		scrollAmount:      100.0,
+
+		backOnEscape: true,
 
 		// Sane configuration values for the engine.
 		flutterAssetsPath: filepath.Join(filepath.Dir(execPath), "flutter_assets"),
@@ -181,6 +185,16 @@ func WindowDimensionLimits(minWidth, minHeight, maxWidth, maxHeight int) Option 
 		c.windowDimensionLimits.minHeight = minHeight
 		c.windowDimensionLimits.maxWidth = maxWidth
 		c.windowDimensionLimits.maxHeight = maxHeight
+	}
+}
+
+// BackOnEscape controls the mapping of the escape key.
+//
+// If true, pops the current route when escape is pressed.
+// If false, escape is delivered to the application.
+func BackOnEscape(backOnEscape bool) Option {
+	return func(c *config) {
+		c.backOnEscape = backOnEscape
 	}
 }
 

--- a/text-input.go
+++ b/text-input.go
@@ -24,6 +24,8 @@ type textinputPlugin struct {
 	clientConf argSetClientConf
 	ed         argsEditingState
 
+	backOnEscape bool
+
 	virtualKeyboardShow func()
 	virtualKeyboardHide func()
 }
@@ -157,8 +159,7 @@ func (p *textinputPlugin) glfwCharCallback(w *glfw.Window, char rune) {
 }
 
 func (p *textinputPlugin) glfwKeyCallback(window *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
-
-	if key == glfw.KeyEscape && action == glfw.Press {
+	if p.backOnEscape && key == glfw.KeyEscape && action == glfw.Press {
 		err := defaultNavigationPlugin.channel.InvokeMethod("popRoute", nil)
 		if err != nil {
 			fmt.Printf("go-flutter: failed to pop route after escape key press: %v\n", err)


### PR DESCRIPTION
See #540.

I'm not sure if there's a more idiomatic way to push the default setting to the text input plugin, but it works in my quick testing.