### PR TITLE
Fix VersionUnavailable warning

### DIFF
--- a/application.go
+++ b/application.go
@@ -69,6 +69,7 @@ func NewApplication(opt ...Option) *Application {
 // Though optional, it is recommended that all embedders set this callback as
 // it will lead to better performance in texture handling.
 func createResourceWindow(window *glfw.Window) (*glfw.Window, error) {
+	opengl.GLFWWindowHint()
 	glfw.WindowHint(glfw.Decorated, glfw.False)
 	glfw.WindowHint(glfw.Visible, glfw.False)
 	if runtime.GOOS == "linux" {


### PR DESCRIPTION
When building an app on hover, we are getting the following error

```
GLFW: An uncaught error has occurred: VersionUnavailable: NSGL: Failed to create OpenGL context
```

This is happening when the Resource Window is created in background. The
Version hint requirements is being reverted to the initial values after we
create the main window, so the resource window does not have a version hint set.

This commit calls the global version hint code after we reset it, to ensure the
resource window have it set.

This fixes the warning, but it's not the actual root-cause to the Flutter 3.0 errors.
It is another  warning that is misleading the investigation on that bug.