### PR TITLE
Implement new method channels to avoid warnings

### DIFF
--- a/application.go
+++ b/application.go
@@ -54,6 +54,7 @@ func NewApplication(opt ...Option) *Application {
 	opt = append(opt, AddPlugin(defaultAccessibilityPlugin))
 	opt = append(opt, AddPlugin(defaultIsolatePlugin))
 	opt = append(opt, AddPlugin(defaultMousecursorPlugin))
+	opt = append(opt, AddPlugin(defaultRestorationPlugin))
 
 	// apply all configs
 	for _, o := range opt {

--- a/navigation.go
+++ b/navigation.go
@@ -17,7 +17,13 @@ var defaultNavigationPlugin = &navigationPlugin{}
 
 func (p *navigationPlugin) InitPlugin(messenger plugin.BinaryMessenger) error {
 	p.channel = plugin.NewMethodChannel(messenger, navigationChannelName, plugin.JSONMethodCodec{})
+
 	// Ignored: This information isn't properly formated to set the window.SetTitle
 	p.channel.HandleFuncSync("routeUpdated", func(_ interface{}) (interface{}, error) { return nil, nil })
+
+	// Currently ignored on platforms other than web
+	p.channel.HandleFuncSync("selectSingleEntryHistory", func(_ interface{}) (interface{}, error) { return nil, nil })
+	p.channel.HandleFuncSync("routeInformationUpdated", func(_ interface{}) (interface{}, error) { return nil, nil })
+
 	return nil
 }

--- a/platform.go
+++ b/platform.go
@@ -38,6 +38,8 @@ func (p *platformPlugin) InitPlugin(messenger plugin.BinaryMessenger) error {
 
 	channel.HandleFuncSync("Clipboard.setData", p.handleClipboardSetData)
 	channel.HandleFuncSync("Clipboard.getData", p.handleClipboardGetData)
+	channel.HandleFuncSync("Clipboard.hasStrings", p.handleClipboardHasString)
+
 	channel.HandleFuncSync("SystemNavigator.pop", p.handleSystemNavigatorPop)
 	channel.HandleFunc("SystemChrome.setApplicationSwitcherDescription", p.handleWindowSetTitle)
 
@@ -85,6 +87,18 @@ func (p *platformPlugin) handleClipboardGetData(arguments interface{}) (reply in
 		Text string `json:"text"`
 	}{
 		Text: clipText,
+	}
+	return reply, nil
+}
+
+func (p *platformPlugin) handleClipboardHasString(arguments interface{}) (reply interface{}, err error) {
+	var clipText string
+	clipText = p.window.GetClipboardString()
+
+	reply = struct {
+		Value bool `json:"value"`
+	}{
+		Value: len(clipText) > 0,
 	}
 	return reply, nil
 }

--- a/restoration.go
+++ b/restoration.go
@@ -1,0 +1,20 @@
+package flutter
+
+import (
+	"github.com/go-flutter-desktop/go-flutter/plugin"
+)
+
+type restorationPlugin struct{}
+
+// all hardcoded because theres not pluggable renderer system.
+var defaultRestorationPlugin = &restorationPlugin{}
+
+var _ Plugin = &restorationPlugin{} // compile-time type check
+
+// InitPlugin implements PluginGLFW
+func (p *restorationPlugin) InitPlugin(messenger plugin.BinaryMessenger) error {
+	channel := plugin.NewMethodChannel(messenger, "flutter/restoration", plugin.StandardMethodCodec{})
+	// Currently not supported. Used only to avoid warnings.
+	channel.HandleFunc("get", func(_ interface{}) (interface{}, error) { return nil, nil })
+	return nil
+}

--- a/restoration.go
+++ b/restoration.go
@@ -11,10 +11,9 @@ var defaultRestorationPlugin = &restorationPlugin{}
 
 var _ Plugin = &restorationPlugin{} // compile-time type check
 
-// InitPlugin implements PluginGLFW
 func (p *restorationPlugin) InitPlugin(messenger plugin.BinaryMessenger) error {
 	channel := plugin.NewMethodChannel(messenger, "flutter/restoration", plugin.StandardMethodCodec{})
-	// Currently not supported. Used only to avoid warnings.
+	// Ignored: desktop doesn't need application "restoration"
 	channel.HandleFunc("get", func(_ interface{}) (interface{}, error) { return nil, nil })
 	return nil
 }

--- a/text-input.go
+++ b/text-input.go
@@ -73,6 +73,8 @@ func (p *textinputPlugin) InitPlugin(messenger plugin.BinaryMessenger) error {
 	})
 	// Ignored: This information is used by the flutter Web Engine
 	p.channel.HandleFuncSync("TextInput.setStyle", func(_ interface{}) (interface{}, error) { return nil, nil })
+	// Ignored: Used on MacOS to position accent selection menu
+	p.channel.HandleFuncSync("TextInput.setCaretRect", func(_ interface{}) (interface{}, error) { return nil, nil })
 	// Ignored: GLFW dosn't support setting the input method of the current cursor location #426
 	p.channel.HandleFuncSync("TextInput.setEditableSizeAndTransform", func(_ interface{}) (interface{}, error) { return nil, nil })
 	// Ignored: GLFW dosn't support setting the input method of the current cursor location #426


### PR DESCRIPTION
Since the upgrade to Flutter 3.0 there were new method channels introduced.

This commit implement a couple of them, to reduce the amount of warnings when running the project.

Fixes #667